### PR TITLE
fix: (minor) extend copyright notice display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@
         </div>
         <footer class="main-footer px-5">
           <div class="footer-left">
-            Copyright © 2018-2020 <a href="https://aleph.im">Aleph.im</a>
+            Copyright © 2018-present <a href="https://aleph.im">Aleph.im</a>
           </div>
           <div class="footer-right">
             v0.1.1


### PR DESCRIPTION
The copyright notice is now displayed until present day (similarly to aleph-account).