### PR TITLE
Fix aggregate details view

### DIFF
--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -124,7 +124,7 @@ export default {
       await this.getMessages()
     },
     async getAggregates() {
-      this.aggregates = await aggretates.fetch(this.address, {api_server: this.api_server})
+      this.aggregates = await aggregates.fetch(this.address, {api_server: this.api_server})
       if (this.aggregates === null)
         this.aggregates = {}
       else if (this.aggregates.profile !== undefined)


### PR DESCRIPTION
A typo in the variable name is stopping the "aggregate details" view from working