### PR TITLE
Replace polling of messages by websockets

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -108,7 +108,7 @@ export default {
     async loadAddresses() {
       // VERY BAD, we load everything for now!
       // TODO: gotta do it on demand.
-      let response = await axios.get(`${this.api_server}/api/v0/addresses/stats.json`)
+      let response = await axios.get(`https://${this.api_server}/api/v0/addresses/stats.json`)
       this.$store.commit('set_addresses_stats', response.data.data)
     }
   },

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import store from './store'
 import BootstrapVue from 'bootstrap-vue'
 import vSelect from 'vue-select'
 
-Vue.component("v-select", vSelect)
+Vue.component('v-select', vSelect)
 Vue.use(BootstrapVue)
 
 Vue.config.productionTip = false

--- a/src/store.js
+++ b/src/store.js
@@ -5,8 +5,7 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
-    api_server: 'https://api2.aleph.im',
-    //api_server: 'http://localhost:8080',
+    api_server: 'api2.aleph.im',
     network_id: 261,
     ipfs_gateway: 'https://ipfs.io/ipfs/',
     account: null,

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
-    api_server: 'https://api1.aleph.im',
+    api_server: 'https://api2.aleph.im',
     //api_server: 'http://localhost:8080',
     network_id: 261,
     ipfs_gateway: 'https://ipfs.io/ipfs/',

--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -124,7 +124,7 @@ export default {
       await this.getMessages()
     },
     async getAggregates() {
-      this.aggregates = await aggretates.fetch(this.address, {api_server: this.api_server})
+      this.aggregates = await aggregates.fetch(this.address, {api_server: 'https://' + this.api_server})
       if (this.aggregates === null)
         this.aggregates = {}
       else if (this.aggregates.profile !== undefined)
@@ -136,7 +136,7 @@ export default {
     },
     async getPosts() {
       // own posts`
-      let response = await axios.get(`${this.api_server}/api/v0/posts.json`, {
+      let response = await axios.get(`https://${this.api_server}/api/v0/posts.json`, {
         params: {
           'types': 'blog_pers,comment,social',
           'addresses': this.address,
@@ -152,7 +152,7 @@ export default {
     },
     async getMessages() {
       // own posts`
-      let response = await axios.get(`${this.api_server}/api/v0/messages.json`, {
+      let response = await axios.get(`https://${this.api_server}/api/v0/messages.json`, {
         params: {
           'addresses': this.address,
           'pagination': this.msg_per_page,
@@ -166,7 +166,7 @@ export default {
       // this.current_msg_page = response.data.pagination_page
     },
     async getStats() {
-      let response = await axios.get(`${this.api_server}/api/v0/addresses/stats.json`, {
+      let response = await axios.get(`https://${this.api_server}/api/v0/addresses/stats.json`, {
         params: {
           addresses: [this.address]
         }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -108,7 +108,7 @@ export default {
     }
   },
   async mounted() {
-    const socket = new WebSocket(`wss://api2.aleph.im/api/ws0/messages?history=${QUEUE_SIZE}`)
+    const socket = new WebSocket(`wss://${this.api_server}/api/ws0/messages?history=${QUEUE_SIZE}`)
     socket.addEventListener('message', this.pushToMessageQueue)
     this.message_socket = socket
   },

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -171,7 +171,7 @@ export default {
       if (this.type) { args['msgType'] = this.type }
 
       let response = await axios.get(
-        `${this.api_server}/api/v0/messages.json`,
+        `https://${this.api_server}/api/v0/messages.json`,
         { params: args }
       )
       this.messages = response.data.messages

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -71,7 +71,7 @@ export default {
       await this.getChannels()
     },
     async getMessages () {
-      let response = await axios.get(`${this.api_server}/api/v0/messages.json`, {
+      let response = await axios.get(`https://${this.api_server}/api/v0/messages.json`, {
         params: {
           'pagination': this.per_page,
           'page': this.page,
@@ -84,7 +84,7 @@ export default {
       this.total_msg = response.data.pagination_total
     },
     async getChannels () {
-      let response = await axios.get(`${this.api_server}/api/v0/channels/list.json`)
+      let response = await axios.get(`https://${this.api_server}/api/v0/channels/list.json`)
       let channels = response.data.channels
 
       this.channels = channels // display all for now


### PR DESCRIPTION
It is worth noting that this is a naive implementation, meaning that every messages (including the first 15, loaded via the `history` query parameter), will trigger an UI update.

[Screencast from 2022-12-13 11-42-56.webm](https://user-images.githubusercontent.com/26065817/207297031-b5237b9f-ab1b-4d0c-b9c4-ee48dc736032.webm)

There is a PR that mitigates this at the expense of code readability (see comment)