### PR TITLE
fix: "undeclared reactive property" warning

### DIFF
--- a/src/components/MessageLink.vue
+++ b/src/components/MessageLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-link :class="'hash '+this.class"
+  <b-link :class="'hash '+this.className"
           :to="{name: 'message-detail', params: {
                address: this.address, chain: this.chain,
                hash: this.hash, type: this.type
@@ -11,6 +11,7 @@
 export default {
   name: 'message-link',
   props: {
+    className: String,
     hash: String,
     chain: String,
     address: String,

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -20,7 +20,7 @@
                           :chain="message.chain"
                           :address="message.sender"
                           :type="message.type"
-             class="break-xs" /><br />
+                          className="break-xs" /><br />
             <span v-b-tooltip.hover :title="dateformat(message.time)">
               {{reldateformat(message.time)}}
             </span>


### PR DESCRIPTION
## The bug

![image](https://user-images.githubusercontent.com/26065817/207909542-798ce227-931d-45dd-9d57-1a4a2e9cc8c1.png)

## Context

A `class` property is handed to a children component without being declared. 