### PR TITLE
fix: Forget message icon

### DIFF
--- a/src/components/MessageIcon.vue
+++ b/src/components/MessageIcon.vue
@@ -1,0 +1,48 @@
+<template>
+  <figure :class="'avatar avatar-sm mr-2 text-white ' + this.iconStyle.background" 
+          :data-initial="this.iconStyle.text" />
+</template>
+
+<script>
+const iconStyles = {
+  POST: {
+    background: 'bg-primary',
+    text: 'Post'
+  },
+  AGGREGATE: {
+    background: 'bg-info',
+    text: 'Aggr'
+  },
+  STORE: {
+    background: 'bg-dark',
+    text: 'Store'
+  },
+  PROGRAM: {
+    background: 'warning',
+    text: 'VM'
+  },
+  FORGET: {
+    background: 'bg-secondary',
+    text: 'F'
+  },
+  __unknown: {
+    background: 'bg-white',
+    text: ''
+  }
+}
+
+export default {
+  name: 'MessageIcon',
+  props: {
+    messageType: String
+  },
+  computed: {
+    iconStyle(){
+      if(iconStyles.hasOwnProperty(this.messageType))
+        return iconStyles[this.messageType]
+
+      return iconStyles[__unknown]
+    }
+  }
+}
+</script>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -3,18 +3,7 @@
     <transition-group name="dynamic-list" tag="div">
       <b-list-group-item v-for="message of messages" :key="message.item_hash">
         <div class="d-flex w-100 font-small">
-          <figure v-if="message.type==='POST'"
-                  class="avatar avatar-sm mr-2 bg-primary text-white"
-                  data-initial="Post"></figure>
-          <figure v-if="message.type==='AGGREGATE'"
-                  class="avatar avatar-sm mr-2 bg-info text-white"
-                  data-initial="Aggr"></figure>
-          <figure v-if="message.type==='STORE'"
-                  class="avatar avatar-sm mr-2 bg-dark text-white"
-                  data-initial="Store"></figure>
-          <figure v-if="message.type==='PROGRAM'"
-                  class="avatar avatar-sm mr-2 warning text-white"
-                  data-initial="VM"></figure>
+          <MessageIcon :messageType="message.type" />
           <div>
             <message-link :hash="message.item_hash"
                           :chain="message.chain"
@@ -56,6 +45,8 @@
 import moment from 'moment'
 import MessageLink from './MessageLink'
 import AddressLink from './AddressLink'
+import MessageIcon from './MessageIcon.vue'
+
 export default {
   name: 'MessageList',
   props: {
@@ -63,8 +54,10 @@ export default {
     animate: Boolean
   },
   components: {
-    MessageLink, AddressLink
-  },
+    MessageLink,
+    AddressLink,
+    MessageIcon
+},
   methods: {
     dateformat (dt) {
       return moment.unix(dt).format('lll')


### PR DESCRIPTION
Add an icon for forget messages.
![image](https://user-images.githubusercontent.com/26065817/207916639-3d5b37fc-9446-4a3e-a38c-bb710db03a2b.png)

Also added an unknown handler for fallback of future messages (white spacer)