### PR TITLE
Add build GitHub action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-22.10
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+
+name: Build app
+
+on:
+  pull_request:
+    branches: ["*"]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-22.10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get git context
+        run: git fetch --prune --unshallow
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
Only build action for now, because linting using the default parameter introduces visual regression. The goal of this action is merely to check that no error occurs during build, and does not certify the project is bug free.

closes #61 