### PR TITLE
Allow users to change the API Server

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -123,7 +123,7 @@ or your build process might be broken! `)
     async loadAddresses () {
       // VERY BAD, we load everything for now!
       // TODO: gotta do it on demand.
-      let response = await axios.get(`https://${this.api_server}/api/v0/addresses/stats.json`)
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/addresses/stats.json`)
       this.$store.commit('set_addresses_stats', response.data.data)
     },
     last_release_is_a_tag () {
@@ -133,6 +133,9 @@ or your build process might be broken! `)
   watch: {
     '$route' (to, from) {
       this.display_menu = false
+    },
+    async 'api_server.host'(){
+      await this.loadAddresses()
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,3 +15,12 @@ new Vue({
   store,
   render: h => h(App)
 }).$mount('#app')
+
+console.log(`%c
+Welcome to Aleph Explorer
+=========================
+You are currently connected to ${store.state.api_server.host}, type:
+set_api_node('http(s)://xxx.xxx.xxx.xxx:4024') to manually set the API server
+`, 'color: #6777ef; font-size: 140%;')
+
+window.set_api_node = url => store.commit('set_api_server', url)

--- a/src/store.js
+++ b/src/store.js
@@ -5,13 +5,17 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
-    api_server: 'api2.aleph.im',
     network_id: 261,
     ipfs_gateway: 'https://ipfs.io/ipfs/',
     account: null,
     profiles: {},
     addresses_stats: [],
     last_broadcast: null,
+    api_server: {
+      host: 'api2.aleph.im',
+      protocol: 'https:',
+      ws_protocol: 'wss:'
+    },
     categories: [ // categories are hard-coded for now...
       'Crypto',
       'Aleph',
@@ -37,6 +41,19 @@ export default new Vuex.Store({
       state.address_alias = {}
       state.alias_address = {}
       state.last_broadcast = null
+    },
+    set_api_server (state, payload) {
+      try {
+        const url = new URL(payload)
+        state.api_server = {
+          host: url.host,
+          protocol: url.protocol,
+          ws_protocol: url.protocol.match('s') ? 'wss:' : 'ws:'
+        }
+        console.log(`API server set to ${state.api_server.host}`)
+      } catch (error) {
+        console.error('Invalid URL format, please prefix with protocol (http(s)://...)')
+      }
     }
   },
   actions: {

--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -124,7 +124,7 @@ export default {
       await this.getMessages()
     },
     async getAggregates() {
-      this.aggregates = await aggregates.fetch(this.address, {api_server: 'https://' + this.api_server})
+      this.aggregates = await aggregates.fetch(this.address, {api_server: 'https://' + this.api_server.host})
       
       if (this.aggregates === null)
         this.aggregates = {}
@@ -137,7 +137,7 @@ export default {
     },
     async getPosts() {
       // own posts`
-      let response = await axios.get(`https://${this.api_server}/api/v0/posts.json`, {
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/posts.json`, {
         params: {
           'types': 'blog_pers,comment,social',
           'addresses': this.address,
@@ -153,7 +153,7 @@ export default {
     },
     async getMessages() {
       // own posts`
-      let response = await axios.get(`https://${this.api_server}/api/v0/messages.json`, {
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/messages.json`, {
         params: {
           'addresses': this.address,
           'pagination': this.msg_per_page,
@@ -167,7 +167,7 @@ export default {
       // this.current_msg_page = response.data.pagination_page
     },
     async getStats() {
-      let response = await axios.get(`https://${this.api_server}/api/v0/addresses/stats.json`, {
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/addresses/stats.json`, {
         params: {
           addresses: [this.address]
         }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -95,14 +95,13 @@ export default {
       return `${message.confirmations.length} confirmations:\n${chains.join(', ')}`;
     },
     pushToMessageQueue (data) {
-      const message = data
-      this.last_messages.unshift(message)
+      this.last_messages.unshift(data)
       this.last_messages.pop()
     },
     openWS () {
       const socket = new WebSocket(`${this.api_server.ws_protocol}//${this.api_server.host}/api/ws0/messages?history=${QUEUE_SIZE}`)
 
-      // Batch the firsts message in a dedicated queue
+      // Batch the firsts messages in a dedicated queue
       // so the "MessageList" component only updates once it is filled
       const prefillQueue = []
       this.last_messages = []

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -171,7 +171,7 @@ export default {
       if (this.type) { args['msgType'] = this.type }
 
       let response = await axios.get(
-        `https://${this.api_server}/api/v0/messages.json`,
+        `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages.json`,
         { params: args }
       )
       this.messages = response.data.messages

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -71,7 +71,7 @@ export default {
       await this.getChannels()
     },
     async getMessages () {
-      let response = await axios.get(`https://${this.api_server}/api/v0/messages.json`, {
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/messages.json`, {
         params: {
           'pagination': this.per_page,
           'page': this.page,
@@ -84,7 +84,7 @@ export default {
       this.total_msg = response.data.pagination_total
     },
     async getChannels () {
-      let response = await axios.get(`https://${this.api_server}/api/v0/channels/list.json`)
+      let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/channels/list.json`)
       let channels = response.data.channels
 
       this.channels = channels // display all for now
@@ -99,6 +99,9 @@ export default {
       await this.refresh()
     },
     async page () {
+      await this.refresh()
+    },
+    async 'api_server.host'() {
       await this.refresh()
     }
   },


### PR DESCRIPTION
This feature allows an user to manually pick another node to fetch messages from, using the javascript console. https://api2.aleph.im is still used by default at page load.

Since this is mainly aimed towards developers it is not displayed in the UI.

To reset the change, simply reload the page or call `set_api_node('https://api2.aleph.im')`.

## Screenshot 

![image](https://user-images.githubusercontent.com/26065817/208599408-cc254b08-92ca-4faa-9299-792bb888fdb3.png)
