### PR TITLE
Fix: Replace Runtime Reference with Code Reference for Retrieving Program Source Code

### DIFF
--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -239,7 +239,7 @@ export default {
     },
     async getProgramSource () {
       try {
-        const ref = this.messages[0].content.runtime.ref
+        const ref = this.messages[0].content.code.ref
   
         if(ref || !this.isProgramSourceLoading || !this.programSource){
           this.isProgramSourceLoading = true


### PR DESCRIPTION
**Description:**

This PR is about an issue where the runtime reference was being used instead of the code reference to retrieve the program's source code. Specifically, the following change has been made in the codebase:

- Replaced:
  ```javascript
  const ref = this.messages[0].content.runtime.ref
  ```
  with:
  ```javascript
  const ref = this.messages[0].content.code.ref
  ```

### Problem:
Currently, the code retrieves the runtime reference instead of the source code reference. This causes issues when the actual source code is needed for various operations

Here are zip and squashfs examples:

https://explorer.aleph.im/address/ETH/0xd73b058FC26932eA58a7eeF81B3CDF77427E8418/message/PROGRAM/d25e409987cd4c2561ed0028958132ae3db2b4bf09dfb0779f777fe428d85bb0

https://explorer.aleph.im/address/ETH/0xBdd89376b071c882cFD96c986bF6Ecaa89dCDfF0/message/PROGRAM/7595abae1419fe99984e53450df0adc682647b865b31a990cb93d1d2b9e2ddc9

### Solution:
The reference has been updated to use `this.messages[0].content.code.ref` to correctly obtain the source code of the program.
