### PR TITLE
Fix bad JSON spacing/display + Upgrade vue-json-pretty 1.9.3->1.9.5 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "moment": "^2.29.4",
     "stisla-theme": "^1.0.5",
     "vue": "^2.6.10",
-    "vue-json-pretty": "1.9.3",
+    "vue-json-pretty": "1.9.5",
     "vue-router": "^3.0.3",
     "vue-select": "^3.20.0",
     "vuex": "^3.0.1"

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -211,7 +211,3 @@ span {
   height: 100px;
   width: 100px;
 }
-
-.vjs-tree {
-  word-wrap: normal !important;
-}

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -211,3 +211,7 @@ span {
   height: 100px;
   width: 100px;
 }
+
+.vjs-tree {
+  word-wrap: normal !important;
+}

--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -212,6 +212,5 @@ export default {
 .vjs-tree {
   font-size: 10px !important;
   line-height: 1.5em;
-  word-wrap: anywhere;
 }
 </style>

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -282,6 +282,5 @@ export default {
 .vjs-tree {
   font-size: 10px !important;
   line-height: 1.5em;
-  word-wrap: anywhere;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ vue-functional-data-merge@^3.1.0:
   resolved "https://registry.yarnpkg.com/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz#08a7797583b7f35680587f8a1d51d729aa1dc657"
   integrity sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA==
 
-vue-json-pretty@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-1.9.3.tgz#aa140406adb28b2c91563fb7f29d530a3be0425d"
-  integrity sha512-b13DP1WGQ+ACUU2K5hmwFfHrHnydCFSTerE7fppeYMojSWN/5EOPODQECfIIRaJ7zzHtPW9OifkThFGPyY0xRg==
+vue-json-pretty@1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-1.9.5.tgz#b59861710e352ee50dc8fafde1090382fa655111"
+  integrity sha512-fwbiH/ky/raX1D4MXRZZLFeKm157e9AkumMD7Y+djdLU1Sb0Tp5q2iOPvCnkWNzRpUfxx/zUjONUG+MIWsqx/w==
 
 vue-router@^3.0.3:
   version "3.6.5"


### PR DESCRIPTION
This is an old issue, I was tired to break my eyes on it everyday.
Keys were squashed vertically to the left in case of long text values, and the overall indentation was also broken. 
Screenshots don't show it, but obviously nested JSONs still work as expected.

Before:
![image](https://github.com/user-attachments/assets/197d102e-1a5d-48d4-8e06-af7876128653)

Now:
![image](https://github.com/user-attachments/assets/d7756e7f-5e8b-49e8-b4a4-c78a5f464822)