### PR TITLE
Rebuild of the explorer on top of the existing Vue 2 / bootstrap-vue stack

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,18 +11,18 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get git context
         run: git fetch --prune --unshallow
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/push_on_ipfs.yaml
+++ b/.github/workflows/push_on_ipfs.yaml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Install and Build
         run: |
@@ -32,7 +32,7 @@ jobs:
   push-to-ipfs:
     name: Push site to IPFS
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       cid_v0: ${{ steps.push_to_ipfs.outputs.cid_v0 }}
       cid_v1: ${{ steps.push_to_ipfs.outputs.cid_v1 }}

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
-      content="width=device-width,initial-scale=1.0,maximum-scale=1,shrink-to-fit=no"
+      content="width=device-width,initial-scale=1.0,shrink-to-fit=no"
     />
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
     <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />

--- a/package.json
+++ b/package.json
@@ -18,23 +18,22 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
-    "@originjs/vite-plugin-commonjs": "^1.0.1",
     "@vitejs/plugin-vue2": "^2.3.4",
     "eslint": "^8.31.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-vue": "^9.8.0",
     "postcss": "^8.4.31",
     "sass": "^1.57.0",
-    "vite": "^4.0.5",
-    "vite-plugin-env-compatible": "^1.1.1",
-    "vite-plugin-html": "^3.2.0"
+    "vite": "^7.3.3"
   },
   "overrides": {
     "ejs": ">=3.1.10",
-    "braces": ">=3.0.3"
+    "braces": ">=3.0.3",
+    "esbuild": ">=0.25.0"
   },
   "resolutions": {
     "ejs": ">=3.1.10",
-    "braces": ">=3.0.3"
+    "braces": ">=3.0.3",
+    "esbuild": ">=0.25.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@noble/curves": "^2.2.0",
     "axios": "^1.12.0",
     "bootstrap-vue": "^2.23.1",
+    "bs58": "^6.0.0",
     "dayjs": "^1.11.20",
+    "ethers": "^6.16.0",
     "stisla-theme": "^1.0.5",
     "vue": "^2.7.0",
     "vue-json-pretty": "1.9.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "axios": "^1.12.0",
     "bootstrap-vue": "^2.23.1",
-    "moment": "^2.29.4",
+    "dayjs": "^1.11.20",
     "stisla-theme": "^1.0.5",
     "vue": "^2.7.0",
     "vue-json-pretty": "1.9.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,10 @@
               <b-nav-item to="/addresses">
                 <i class="fas fa-address-book"></i><span>Addresses</span>
               </b-nav-item>
+              <li class="menu-header">Trust</li>
+              <b-nav-item to="/verify">
+                <i class="fas fa-shield-alt"></i><span>Verify</span>
+              </b-nav-item>
               <li class="menu-header">Discover</li>
               <b-nav-item to="/ecosystem">
                 <i class="fas fa-th-large"></i><span>Ecosystem</span>

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,7 @@
               </b-nav-item>
               <li class="menu-header">Trust</li>
               <b-nav-item to="/verify">
-                <i class="fas fa-shield-alt"></i><span>Verify</span>
+                <i class="fas fa-shield-alt"></i><span>Verifier</span>
               </b-nav-item>
               <li class="menu-header">Discover</li>
               <b-nav-item to="/ecosystem">

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
       <div class="main-zone">
         <div class="navbar-bg"></div>
         <nav class="navbar navbar-expand-lg main-navbar">
-          <ul class="navbar-nav mr-auto mr-3">
+          <ul class="navbar-nav mr-3">
             <li v-if="window.width < 1024">
               <b-link
                 @click="display_menu = !display_menu"
@@ -14,7 +14,10 @@
               ></b-link>
             </li>
           </ul>
-          <b-navbar-brand to="/"
+          <div class="header-search">
+            <SearchBar />
+          </div>
+          <b-navbar-brand to="/" class="ml-auto pl-3"
             ><h1 class="h3-size">Aleph Cloud<br />explorer</h1></b-navbar-brand
           >
         </nav>
@@ -163,8 +166,10 @@
 
 <script>
 import { mapState } from "vuex";
+import SearchBar from "@/components/SearchBar.vue";
 export default {
   name: "app",
+  components: { SearchBar },
   data() {
     return {
       window: {
@@ -241,5 +246,26 @@ or your build process might be broken! `);
   font-size: 1.25rem;
   font-weight: 500;
   margin: 0;
+}
+
+.main-navbar {
+  align-items: center;
+}
+
+.main-navbar .header-search {
+  flex: 1 1 auto;
+  max-width: 720px;
+  min-width: 220px;
+}
+
+.main-navbar .header-search .dashboard-search {
+  margin-bottom: 0;
+}
+
+@media (max-width: 575px) {
+  .main-navbar .header-search {
+    max-width: none;
+    min-width: 140px;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,8 @@
             <SearchBar />
           </div>
           <b-navbar-brand to="/" class="ml-auto pl-3"
-            ><h1 class="h3-size">Aleph Cloud<br />explorer</h1></b-navbar-brand
+            ><h1 class="h3-size">Aleph Cloud<br class="d-none d-sm-inline" /><span
+              class="d-none d-sm-inline">explorer</span></h1></b-navbar-brand
           >
         </nav>
 
@@ -246,6 +247,13 @@ or your build process might be broken! `);
   font-size: 1.25rem;
   font-weight: 500;
   margin: 0;
+}
+
+@media (max-width: 575px) {
+  .navbar-brand .h3-size {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
 }
 
 .main-navbar {

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,36 +29,7 @@
             <router-view />
           </section>
         </div>
-        <footer class="main-footer px-5">
-          <div class="footer-left">
-            Copyright © 2018-present
-            <a href="https://aleph.cloud">Aleph Cloud</a>
-          </div>
-          <div class="footer-right">
-            <template v-if="app_version">
-              <template v-if="last_release_is_a_tag()">
-                <a
-                  :href="
-                    'https://github.com/aleph-im/aleph-explorer/tree/' +
-                    app_version
-                  "
-                  >{{ app_version }}</a
-                >
-              </template>
-              <template v-else>
-                {{ app_version }}
-              </template>
-            </template>
-            <a
-              href="https://github.com/aleph-im/aleph-explorer"
-              class="card-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <i class="fab fa-github"></i>
-            </a>
-          </div>
-        </footer>
+        <EcosystemFooter />
       </div>
       <transition name="fade">
         <div class="main-sidebar" v-if="(window.width >= 1024) | display_menu">
@@ -77,6 +48,10 @@
               </b-nav-item>
               <b-nav-item to="/addresses">
                 <i class="fas fa-address-book"></i><span>Addresses</span>
+              </b-nav-item>
+              <li class="menu-header">Discover</li>
+              <b-nav-item to="/ecosystem">
+                <i class="fas fa-th-large"></i><span>Ecosystem</span>
               </b-nav-item>
             </ul>
             <div class="px-3 pt-4 pb-2 hide-sidebar-mini">
@@ -205,9 +180,10 @@
 <script>
 import { mapState } from "vuex";
 import SearchBar from "@/components/SearchBar.vue";
+import EcosystemFooter from "@/components/EcosystemFooter.vue";
 export default {
   name: "app",
-  components: { SearchBar },
+  components: { SearchBar, EcosystemFooter },
   data() {
     return {
       window: {
@@ -215,7 +191,6 @@ export default {
         height: 0,
       },
       display_menu: false,
-      app_version: GIT_DESCRIBE_TAGS || "unknown build",
     };
   },
   computed: mapState({
@@ -242,9 +217,6 @@ or your build process might be broken! `);
     handleResize() {
       this.window.width = window.innerWidth;
       this.window.height = window.innerHeight;
-    },
-    last_release_is_a_tag() {
-      return /\d+-.[0-9A-F]{7}$/i.test(this.app_version);
     },
   },
   watch: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -79,14 +79,51 @@
                 <i class="fas fa-address-book"></i><span>Addresses</span>
               </b-nav-item>
             </ul>
-            <div class="p-3 mt-4 mb-4 hide-sidebar-mini">
+            <div class="px-3 pt-4 pb-2 hide-sidebar-mini">
               <b-link
                 to="/about"
-                class="btn btn-primary btn-lg btn-icon-split btn-block"
+                class="btn btn-primary btn-lg btn-icon-split btn-block mb-2"
               >
                 <i class="far fa-question-circle"></i>
                 <div>About</div>
               </b-link>
+              <b-link
+                href="https://docs.aleph.cloud/"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn btn-primary btn-lg btn-icon-split btn-block mb-0"
+              >
+                <i class="fas fa-book"></i>
+                <div>Documentation</div>
+              </b-link>
+            </div>
+            <div class="sidebar-socials hide-sidebar-mini">
+              <a
+                href="https://t.me/alephim/119590"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Telegram"
+              >
+                <i class="fab fa-telegram"></i>
+              </a>
+              <a
+                href="https://x.com/aleph_im"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="X (Twitter)"
+              >
+                <svg viewBox="0 0 384 512" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+                  <path d="M306.2 32l77.5 0-1.4 2L230.7 256 382.3 478l1.4 2-77.5 0L192 312.8 77.8 480 .3 480l1.4-2L153.3 256 1.7 34 .3 32l77.5 0L192 199.2 306.2 32z"/>
+                </svg>
+              </a>
+              <a
+                href="https://www.aleph.cloud/blog"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Blog"
+              >
+                <i class="fas fa-globe"></i>
+              </a>
             </div>
           </aside>
         </div>
@@ -254,6 +291,34 @@ or your build process might be broken! `);
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
+}
+
+.sidebar-socials {
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 1.25rem 1rem 1rem;
+}
+
+.sidebar-socials a {
+  color: #fff !important;
+  opacity: 0.7;
+  font-size: 1.25rem;
+  line-height: 1;
+  height: auto !important;
+  display: inline-flex;
+  align-items: center;
+  transition: opacity 0.15s;
+}
+
+.sidebar-socials a:hover {
+  opacity: 1;
+  background: transparent !important;
+}
+
+.sidebar-socials svg {
+  width: 0.85em;
+  height: 0.85em;
 }
 
 .main-navbar {

--- a/src/assets/stisla-variables.scss
+++ b/src/assets/stisla-variables.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "sass:map";
+
 // =============================================
 // COLOR SYSTEM
 // =============================================
@@ -143,15 +146,15 @@ $grid-breakpoints: (
 // =============================================
 
 @function color($key) {
-  @return map-get($colors, $key);
+  @return map.get($colors, $key);
 }
 
 @function color_lighten($key, $amount) {
-  @return lighten(map-get($colors, $key), $amount);
+  @return color.adjust(map.get($colors, $key), $lightness: $amount);
 }
 
 @function color_darken($key, $amount) {
-  @return darken(map-get($colors, $key), $amount);
+  @return color.adjust(map.get($colors, $key), $lightness: -$amount);
 }
 
 @function to_opacity($color, $opacity) {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -10,8 +10,11 @@ html {
 // App styles
 .main-content {
   padding: $spacing-sm $spacing-lg $spacing-lg $spacing-lg;
+  // Grow to fill the main-zone so the footer below us sticks to the
+  // bottom of the viewport when the page content is short.
+  flex-grow: 1;
   // Clip horizontal overflow so wide tables/cards don't blow out the
-  // viewport on phones — their own `table-responsive` wrappers still
+  // viewport on phones; their own `table-responsive` wrappers still
   // scroll horizontally inside the card.
   overflow-x: hidden;
 }
@@ -54,7 +57,10 @@ html {
   min-height: 100vh;
 
   .main-zone {
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
+    min-height: 100vh;
     // Make room for both fixed left bars on desktop: the navigator
     // icon strip and the main sidebar.
     margin-left: calc(#{$navigator-width} + #{$sidebar-min-width});
@@ -236,7 +242,7 @@ nav.navbar {
     flex-direction: column-reverse;
 
     .main-zone {
-      // Mobile sidebar is an overlay (position: absolute) — main-zone
+      // Mobile sidebar is an overlay (position: absolute); main-zone
       // shouldn't reserve room for it.
       margin-left: 0;
     }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -1,5 +1,12 @@
 @use "sass:map";
 
+// Drop the document-level font size from the browser default (16px) to
+// 14px so the explorer reads at a denser, etherscan-style scale.
+// Everything sized in rem scales proportionally.
+html {
+  font-size: 14px;
+}
+
 // App styles
 .main-content {
   padding: $spacing-sm $spacing-lg $spacing-lg $spacing-lg;

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -3,6 +3,42 @@
 // App styles
 .main-content {
   padding: $spacing-sm $spacing-lg $spacing-lg $spacing-lg;
+  // Clip horizontal overflow so wide tables/cards don't blow out the
+  // viewport on phones — their own `table-responsive` wrappers still
+  // scroll horizontally inside the card.
+  overflow-x: hidden;
+}
+
+@media (max-width: 575px) {
+  .main-content {
+    padding-left: $spacing-base;
+    padding-right: $spacing-base;
+  }
+}
+
+// Cards must not let descendant tables / JSON viewers blow past the
+// viewport width. Tables keep their own .table-responsive horizontal
+// scroll; everything else is clipped or wraps.
+.card {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+// On phones, let MessageList row children wrap to a new line instead
+// of forcing the parent wider than the screen.
+@media (max-width: 575px) {
+  .card .list-group-item > .d-flex {
+    flex-wrap: wrap;
+    row-gap: 0.35rem;
+  }
+}
+
+// Make vue-json-pretty content scroll inside its tab pane instead of
+// pushing the surrounding card wider on phones.
+.vjs-tree,
+.vjs-tree-list {
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .main-wrapper {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -48,6 +48,9 @@
 
   .main-zone {
     flex-grow: 1;
+    // Make room for both fixed left bars on desktop: the navigator
+    // icon strip and the main sidebar.
+    margin-left: calc(#{$navigator-width} + #{$sidebar-min-width});
   }
 }
 
@@ -62,6 +65,12 @@ nav.navbar {
 }
 
 .navigator {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  z-index: 101;
+  overflow-y: auto;
   background: $navigator-bg;
   width: $navigator-width;
 
@@ -120,9 +129,14 @@ nav.navbar {
 }
 
 .main-sidebar {
-  position: inherit !important;
+  position: fixed !important;
+  top: 0;
+  left: $navigator-width;
   min-width: $sidebar-min-width;
-  height: auto;
+  width: $sidebar-min-width;
+  height: 100vh;
+  overflow-y: auto;
+  z-index: 100;
   background: $sidebar-bg;
   color: color(white);
   font-family: $font-family-title;
@@ -186,6 +200,8 @@ nav.navbar {
     .sidebar-menu {
       /*min-height: calc(100vh - 75.6px - 42.5px - 5rem);*/
       flex-grow: 1;
+      overflow-y: auto;
+      min-height: 0;
     }
   }
 
@@ -212,8 +228,16 @@ nav.navbar {
   .main-wrapper {
     flex-direction: column-reverse;
 
+    .main-zone {
+      // Mobile sidebar is an overlay (position: absolute) — main-zone
+      // shouldn't reserve room for it.
+      margin-left: 0;
+    }
+
     .main-sidebar {
       width: 100%;
+      left: 0;
+      height: auto;
       position: absolute !important;
 
       #sidebar-wrapper {

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // App styles
 .main-content {
   padding: $spacing-sm $spacing-lg $spacing-lg $spacing-lg;
@@ -170,7 +172,7 @@ nav.navbar {
   }
 }
 
-@media only screen and (max-width: map-get($grid-breakpoints, lg)) {
+@media only screen and (max-width: map.get($grid-breakpoints, lg)) {
   .main-wrapper {
     flex-direction: column-reverse;
 

--- a/src/components/DashboardStats.vue
+++ b/src/components/DashboardStats.vue
@@ -59,7 +59,14 @@
     <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Next on-chain commit in</div>
-        <div class="stat-value">{{ countdownText }}</div>
+        <div class="stat-value">
+          <div v-if="isAnchoring" class="progress-anchoring"
+            v-b-tooltip.hover title="A new commit is being assembled and broadcast">
+            <div class="progress-anchoring__bar"></div>
+            <span class="progress-anchoring__label">anchoring</span>
+          </div>
+          <template v-else>{{ countdownText }}</template>
+        </div>
         <div class="stat-sub">≈1h commit cadence</div>
       </div>
     </b-col>
@@ -141,7 +148,12 @@ export default {
       if (!this.commitAnchor) return '-'
       const target = this.commitAnchor + COMMIT_CADENCE_MS
       const remaining = target - this.now
-      return remaining > 0 ? fmtDuration(remaining) : 'overdue'
+      return remaining > 0 ? fmtDuration(remaining) : 'anchoring…'
+    },
+    isAnchoring() {
+      if (!this.commitAnchor) return false
+      const target = this.commitAnchor + COMMIT_CADENCE_MS
+      return target - this.now <= 0
     }
   },
   mounted() {
@@ -234,5 +246,58 @@ export default {
 
 .stat-warn {
   color: #d9245a;
+}
+
+/* Indeterminate "anchoring in progress" bar shown when the 1h commit
+   cadence has elapsed but the new committed height hasn't surfaced
+   in the metrics poll yet. A purple shimmer slides across a tinted
+   track, with the word "anchoring" centered on top. */
+.progress-anchoring {
+  position: relative;
+  width: 100%;
+  height: 1.5rem;
+  background: rgba(81, 0, 205, 0.08);
+  border-radius: 0.3rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.progress-anchoring__bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg,
+    rgba(81, 0, 205, 0),
+    rgba(81, 0, 205, 0.45) 50%,
+    rgba(81, 0, 205, 0));
+  animation: anchoring-slide 1.8s linear infinite;
+  will-change: left;
+}
+
+.progress-anchoring__label {
+  position: relative;
+  z-index: 1;
+  font-size: 0.78rem;
+  color: #5100cd;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+@keyframes anchoring-slide {
+  0%   { left: -40%; }
+  100% { left: 100%; }
+}
+
+@media (max-width: 575px) {
+  .progress-anchoring {
+    height: 1.05rem;
+  }
+  .progress-anchoring__label {
+    font-size: 0.65rem;
+  }
 }
 </style>

--- a/src/components/DashboardStats.vue
+++ b/src/components/DashboardStats.vue
@@ -29,7 +29,7 @@
           <a v-if="lastBlock" :href="contractUrl" target="_blank" rel="noopener noreferrer">
             block #{{ lastBlock }} <i class="fas fa-external-link-alt fa-xs"></i>
           </a>
-          <span v-else>—</span>
+          <span v-else>-</span>
         </div>
         <div class="stat-sub" v-if="lastBlock">
           {{ commitAgoText }}
@@ -73,7 +73,7 @@ const COMMIT_CADENCE_MS = 3600 * 1000
 const ALEPH_ETH_CONTRACT = '0x166fd4299364b21c7567e163d85d78d2fb2f8ad5'
 
 const fmt = (n) => {
-  if (n === null || n === undefined) return '—'
+  if (n === null || n === undefined) return '-'
   return Number(n).toLocaleString('en-US')
 }
 
@@ -138,7 +138,7 @@ export default {
       return fmt(this.message_rates?.h24)
     },
     countdownText() {
-      if (!this.commitAnchor) return '—'
+      if (!this.commitAnchor) return '-'
       const target = this.commitAnchor + COMMIT_CADENCE_MS
       const remaining = target - this.now
       return remaining > 0 ? fmtDuration(remaining) : 'overdue'

--- a/src/components/DashboardStats.vue
+++ b/src/components/DashboardStats.vue
@@ -1,6 +1,6 @@
 <template>
   <b-row class="dashboard-stats">
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Total messages</div>
         <div class="stat-value">{{ totalMessages }}</div>
@@ -11,7 +11,7 @@
       </div>
     </b-col>
 
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Pending messages</div>
         <div class="stat-value" :class="{ 'stat-warn': pendingCount > 100 }">{{ pendingCount }}</div>
@@ -22,7 +22,7 @@
       </div>
     </b-col>
 
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Last on-chain commit</div>
         <div class="stat-value">
@@ -37,7 +37,7 @@
       </div>
     </b-col>
 
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Users on Aleph</div>
         <div class="stat-value">{{ totalAccounts }}</div>
@@ -48,7 +48,7 @@
       </div>
     </b-col>
 
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Message rate</div>
         <div class="stat-value">{{ rateH1 }}<span class="stat-unit">/h</span></div>
@@ -56,7 +56,7 @@
       </div>
     </b-col>
 
-    <b-col cols="12" md="4">
+    <b-col cols="6" md="4" class="mb-3">
       <div class="stat-card">
         <div class="stat-label">Next on-chain commit in</div>
         <div class="stat-value">{{ countdownText }}</div>
@@ -145,7 +145,9 @@ export default {
     }
   },
   mounted() {
-    this.tickTimer = setInterval(() => { this.now = Date.now() }, 200)
+    // 1-second tick is sufficient for the MM:SS countdown display
+    // and avoids unnecessary redraws on mobile.
+    this.tickTimer = setInterval(() => { this.now = Date.now() }, 1000)
   },
   beforeDestroy() {
     if (this.tickTimer) clearInterval(this.tickTimer)
@@ -162,7 +164,6 @@ export default {
   background: #fff;
   border-radius: 0.5rem;
   padding: 1rem 1.25rem;
-  margin-bottom: 1rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   height: 100%;
 }
@@ -179,6 +180,22 @@ export default {
   font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.1;
+  word-break: break-word;
+}
+
+@media (max-width: 575px) {
+  .stat-card {
+    padding: 0.75rem 0.9rem;
+  }
+  .stat-value {
+    font-size: 1.05rem;
+  }
+  .stat-sub-highlight {
+    font-size: 0.78rem !important;
+  }
+  .stat-label {
+    font-size: 0.65rem;
+  }
 }
 
 .stat-unit {

--- a/src/components/DashboardStats.vue
+++ b/src/components/DashboardStats.vue
@@ -1,0 +1,221 @@
+<template>
+  <b-row class="dashboard-stats">
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Total messages</div>
+        <div class="stat-value">{{ totalMessages }}</div>
+        <div class="stat-sub stat-sub-highlight">
+          <i class="fas fa-database"></i>
+          <strong>{{ totalFiles }}</strong> files stored
+        </div>
+      </div>
+    </b-col>
+
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Pending messages</div>
+        <div class="stat-value" :class="{ 'stat-warn': pendingCount > 100 }">{{ pendingCount }}</div>
+        <div class="stat-sub stat-sub-highlight">
+          <i class="fas fa-network-wired"></i>
+          <strong>{{ peersTotal }}</strong> peers
+        </div>
+      </div>
+    </b-col>
+
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Last on-chain commit</div>
+        <div class="stat-value">
+          <a v-if="lastBlock" :href="contractUrl" target="_blank" rel="noopener noreferrer">
+            block #{{ lastBlock }} <i class="fas fa-external-link-alt fa-xs"></i>
+          </a>
+          <span v-else>—</span>
+        </div>
+        <div class="stat-sub" v-if="lastBlock">
+          {{ commitAgoText }}
+        </div>
+      </div>
+    </b-col>
+
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Users on Aleph</div>
+        <div class="stat-value">{{ totalAccounts }}</div>
+        <div class="stat-sub">
+          <i class="fas fa-users"></i>
+          publishing messages, files &amp; cloud resources
+        </div>
+      </div>
+    </b-col>
+
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Message rate</div>
+        <div class="stat-value">{{ rateH1 }}<span class="stat-unit">/h</span></div>
+        <div class="stat-sub">{{ rateH24 }} in the last 24h</div>
+      </div>
+    </b-col>
+
+    <b-col cols="12" md="4">
+      <div class="stat-card">
+        <div class="stat-label">Next on-chain commit in</div>
+        <div class="stat-value">{{ countdownText }}</div>
+        <div class="stat-sub">≈1h commit cadence</div>
+      </div>
+    </b-col>
+  </b-row>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+const COMMIT_CADENCE_MS = 3600 * 1000
+const ALEPH_ETH_CONTRACT = '0x166fd4299364b21c7567e163d85d78d2fb2f8ad5'
+
+const fmt = (n) => {
+  if (n === null || n === undefined) return '—'
+  return Number(n).toLocaleString('en-US')
+}
+
+const fmtDuration = (ms) => {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export default {
+  name: 'DashboardStats',
+  data() {
+    return {
+      now: Date.now(),
+      tickTimer: null
+    }
+  },
+  computed: {
+    ...mapState({
+      metrics: state => state.metrics,
+      eth_block_observed_at: state => state.eth_block_observed_at,
+      eth_block_committed_at: state => state.eth_block_committed_at,
+      message_rates: state => state.message_rates,
+      addresses_pagination: state => state.addresses_pagination
+    }),
+    totalMessages() {
+      return fmt(this.metrics?.pyaleph_status_sync_messages_total)
+    },
+    totalFiles() {
+      return fmt(this.metrics?.pyaleph_status_sync_permanent_files_total)
+    },
+    pendingCount() {
+      return fmt(this.metrics?.pyaleph_status_sync_pending_messages_total)
+    },
+    peersTotal() {
+      return fmt(this.metrics?.pyaleph_status_peers_total)
+    },
+    lastBlock() {
+      return this.metrics?.pyaleph_status_chain_eth_last_committed_height ?? null
+    },
+    contractUrl() {
+      return `https://etherscan.io/address/${ALEPH_ETH_CONTRACT}`
+    },
+    commitAnchor() {
+      // Prefer the real block timestamp from the ETH RPC; fall back to the
+      // moment we first observed the new height (within metrics-poll resolution).
+      return this.eth_block_committed_at || this.eth_block_observed_at
+    },
+    commitAgoText() {
+      if (!this.commitAnchor) return ''
+      const elapsed = Math.max(0, this.now - this.commitAnchor)
+      return `${fmtDuration(elapsed)} ago`
+    },
+    totalAccounts() {
+      return fmt(this.addresses_pagination?.total)
+    },
+    rateH1() {
+      return fmt(this.message_rates?.h1)
+    },
+    rateH24() {
+      return fmt(this.message_rates?.h24)
+    },
+    countdownText() {
+      if (!this.commitAnchor) return '—'
+      const target = this.commitAnchor + COMMIT_CADENCE_MS
+      const remaining = target - this.now
+      return remaining > 0 ? fmtDuration(remaining) : 'overdue'
+    }
+  },
+  mounted() {
+    this.tickTimer = setInterval(() => { this.now = Date.now() }, 200)
+  },
+  beforeDestroy() {
+    if (this.tickTimer) clearInterval(this.tickTimer)
+  }
+}
+</script>
+
+<style scoped>
+.dashboard-stats {
+  margin-bottom: 1.5rem;
+}
+
+.stat-card {
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  height: 100%;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6c757d;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.stat-unit {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: #6c757d;
+}
+
+.stat-sub {
+  font-size: 0.75rem;
+  color: #6c757d;
+  margin-top: 0.25rem;
+  min-height: 1em;
+}
+
+.stat-sub .fas {
+  margin-right: 0.35rem;
+  opacity: 0.7;
+}
+
+.stat-sub-highlight {
+  font-size: 0.95rem;
+  color: #5100cd;
+  font-weight: 500;
+  margin-top: 0.4rem;
+}
+
+.stat-sub-highlight strong {
+  font-weight: 700;
+}
+
+.stat-sub-highlight .fas {
+  margin-right: 0.35rem;
+  opacity: 0.85;
+}
+
+.stat-warn {
+  color: #d9245a;
+}
+</style>

--- a/src/components/EcosystemFooter.vue
+++ b/src/components/EcosystemFooter.vue
@@ -1,30 +1,7 @@
 <template>
   <div class="ecosystem-footer">
     <b-container fluid>
-      <b-row>
-        <b-col v-for="group in groups" :key="group.key" cols="6" md="3" class="mb-3">
-          <h6 class="ecosystem-footer__heading">{{ group.title }}</h6>
-          <ul class="ecosystem-footer__list">
-            <li v-for="item in group.items" :key="item.name">
-              <a :href="item.url" target="_blank" rel="noopener noreferrer">
-                <i :class="item.icon"></i> {{ item.name }}
-              </a>
-            </li>
-          </ul>
-        </b-col>
-      </b-row>
-      <b-row class="mt-2 pt-3 ecosystem-footer__resources">
-        <b-col cols="12" class="d-flex flex-wrap">
-          <a v-for="link in resources" :key="link.name" :href="link.url" target="_blank"
-            rel="noopener noreferrer" class="ecosystem-footer__resource" :title="link.name">
-            <i :class="link.icon"></i> {{ link.name }}
-          </a>
-          <b-link to="/ecosystem" class="ecosystem-footer__resource ml-auto">
-            See full ecosystem <i class="fas fa-chevron-right fa-xs"></i>
-          </b-link>
-        </b-col>
-      </b-row>
-      <b-row class="mt-2 pt-3 ecosystem-footer__legal">
+      <b-row class="ecosystem-footer__legal">
         <b-col cols="12" md="8" class="ecosystem-footer__copy">
           Copyright © 2018-present
           <a href="https://aleph.cloud" target="_blank" rel="noopener noreferrer">Aleph Cloud</a>
@@ -45,18 +22,28 @@
           </a>
         </b-col>
       </b-row>
+      <b-row class="mt-2 pt-3 ecosystem-footer__resources">
+        <b-col cols="12" class="d-flex flex-wrap">
+          <a v-for="link in resources" :key="link.name" :href="link.url" target="_blank"
+            rel="noopener noreferrer" class="ecosystem-footer__resource" :title="link.name">
+            <i :class="link.icon"></i> {{ link.name }}
+          </a>
+          <b-link to="/ecosystem" class="ecosystem-footer__resource ml-auto">
+            See full ecosystem <i class="fas fa-chevron-right fa-xs"></i>
+          </b-link>
+        </b-col>
+      </b-row>
     </b-container>
   </div>
 </template>
 
 <script>
-import { ECOSYSTEM_GROUPS, RESOURCE_LINKS } from '@/lib/ecosystem.js'
+import { RESOURCE_LINKS } from '@/lib/ecosystem.js'
 
 export default {
   name: 'EcosystemFooter',
   data() {
     return {
-      groups: ECOSYSTEM_GROUPS,
       resources: RESOURCE_LINKS,
       app_version: GIT_DESCRIBE_TAGS || 'unknown build'
     }
@@ -71,52 +58,9 @@ export default {
 
 <style scoped>
 .ecosystem-footer {
-  padding: 2rem 0 1.25rem;
+  padding: 1.25rem 0;
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   background: #fafafd;
-}
-
-.ecosystem-footer__heading {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #6c757d;
-  margin-bottom: 0.6rem;
-  font-weight: 700;
-}
-
-.ecosystem-footer__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.ecosystem-footer__list li {
-  margin-bottom: 0.4rem;
-}
-
-.ecosystem-footer__list a {
-  color: #2b1865;
-  font-size: 0.85rem;
-  font-weight: 500;
-  text-decoration: none;
-}
-
-.ecosystem-footer__list a:hover {
-  color: #5100cd;
-  text-decoration: underline;
-}
-
-.ecosystem-footer__list .fas,
-.ecosystem-footer__list .fab {
-  margin-right: 0.35rem;
-  width: 1em;
-  text-align: center;
-  opacity: 0.7;
-}
-
-.ecosystem-footer__resources {
-  border-top: 1px dashed rgba(0, 0, 0, 0.08);
 }
 
 .ecosystem-footer__resource {
@@ -133,8 +77,11 @@ export default {
   color: #5100cd;
 }
 
-.ecosystem-footer__legal {
+.ecosystem-footer__resources {
   border-top: 1px dashed rgba(0, 0, 0, 0.08);
+}
+
+.ecosystem-footer__legal {
   font-size: 0.8rem;
   color: #6c757d;
 }

--- a/src/components/EcosystemFooter.vue
+++ b/src/components/EcosystemFooter.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="ecosystem-footer">
+    <b-container fluid>
+      <b-row>
+        <b-col v-for="group in groups" :key="group.key" cols="6" md="3" class="mb-3">
+          <h6 class="ecosystem-footer__heading">{{ group.title }}</h6>
+          <ul class="ecosystem-footer__list">
+            <li v-for="item in group.items" :key="item.name">
+              <a :href="item.url" target="_blank" rel="noopener noreferrer">
+                <i :class="item.icon"></i> {{ item.name }}
+              </a>
+            </li>
+          </ul>
+        </b-col>
+      </b-row>
+      <b-row class="mt-2 pt-3 ecosystem-footer__resources">
+        <b-col cols="12" class="d-flex flex-wrap">
+          <a v-for="link in resources" :key="link.name" :href="link.url" target="_blank"
+            rel="noopener noreferrer" class="ecosystem-footer__resource" :title="link.name">
+            <i :class="link.icon"></i> {{ link.name }}
+          </a>
+          <b-link to="/ecosystem" class="ecosystem-footer__resource ml-auto">
+            See full ecosystem <i class="fas fa-chevron-right fa-xs"></i>
+          </b-link>
+        </b-col>
+      </b-row>
+      <b-row class="mt-2 pt-3 ecosystem-footer__legal">
+        <b-col cols="12" md="8" class="ecosystem-footer__copy">
+          Copyright © 2018-present
+          <a href="https://aleph.cloud" target="_blank" rel="noopener noreferrer">Aleph Cloud</a>
+          <template v-if="app_version">
+            <span class="ecosystem-footer__version">
+              <template v-if="last_release_is_a_tag()">
+                <a :href="'https://github.com/aleph-im/aleph-explorer/tree/' + app_version"
+                  target="_blank" rel="noopener noreferrer">{{ app_version }}</a>
+              </template>
+              <template v-else>{{ app_version }}</template>
+            </span>
+          </template>
+        </b-col>
+        <b-col cols="12" md="4" class="ecosystem-footer__github">
+          <a href="https://github.com/aleph-im" target="_blank"
+            rel="noopener noreferrer" title="Aleph on GitHub">
+            <i class="fab fa-github"></i> aleph-im
+          </a>
+        </b-col>
+      </b-row>
+    </b-container>
+  </div>
+</template>
+
+<script>
+import { ECOSYSTEM_GROUPS, RESOURCE_LINKS } from '@/lib/ecosystem.js'
+
+export default {
+  name: 'EcosystemFooter',
+  data() {
+    return {
+      groups: ECOSYSTEM_GROUPS,
+      resources: RESOURCE_LINKS,
+      app_version: GIT_DESCRIBE_TAGS || 'unknown build'
+    }
+  },
+  methods: {
+    last_release_is_a_tag() {
+      return /\d+-.[0-9A-F]{7}$/i.test(this.app_version)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.ecosystem-footer {
+  padding: 2rem 0 1.25rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  background: #fafafd;
+}
+
+.ecosystem-footer__heading {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6c757d;
+  margin-bottom: 0.6rem;
+  font-weight: 700;
+}
+
+.ecosystem-footer__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ecosystem-footer__list li {
+  margin-bottom: 0.4rem;
+}
+
+.ecosystem-footer__list a {
+  color: #2b1865;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.ecosystem-footer__list a:hover {
+  color: #5100cd;
+  text-decoration: underline;
+}
+
+.ecosystem-footer__list .fas,
+.ecosystem-footer__list .fab {
+  margin-right: 0.35rem;
+  width: 1em;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.ecosystem-footer__resources {
+  border-top: 1px dashed rgba(0, 0, 0, 0.08);
+}
+
+.ecosystem-footer__resource {
+  color: #6c757d;
+  font-size: 0.8rem;
+  margin-right: 1.25rem;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.ecosystem-footer__resource:hover {
+  color: #5100cd;
+}
+
+.ecosystem-footer__legal {
+  border-top: 1px dashed rgba(0, 0, 0, 0.08);
+  font-size: 0.8rem;
+  color: #6c757d;
+}
+
+.ecosystem-footer__copy a {
+  color: #2b1865;
+  text-decoration: none;
+}
+
+.ecosystem-footer__copy a:hover {
+  color: #5100cd;
+  text-decoration: underline;
+}
+
+.ecosystem-footer__version {
+  margin-left: 0.4rem;
+  opacity: 0.7;
+}
+
+.ecosystem-footer__github {
+  text-align: right;
+}
+
+.ecosystem-footer__github a {
+  color: #6c757d;
+  text-decoration: none;
+}
+
+.ecosystem-footer__github a:hover {
+  color: #5100cd;
+}
+
+@media (max-width: 767px) {
+  .ecosystem-footer__github {
+    text-align: left;
+    margin-top: 0.5rem;
+  }
+}
+</style>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -32,8 +32,9 @@
               {{message.content.size/1000000}} MB</b-badge> -->
           </div>
           <div class="ml-auto">
-            <b-badge v-b-tooltip.hover :title="confirm_text(message)"
-            variant="light" v-if="message.confirmations">{{message.confirmations.length}}</b-badge>
+            <b-badge v-if="message.confirmed" variant="light" v-b-tooltip.hover
+              :title="confirm_text(message)">confirmed</b-badge>
+            <b-badge v-else variant="light">pending</b-badge>
           </div>
         </div>
       </b-list-group-item>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -97,4 +97,15 @@ export default {
   position: absolute;
   width: 100%;
 }
+
+// Brief brand-purple background flash on newly-arrived rows so the eye
+// catches the live update.
+.dynamic-list-enter-active {
+  animation: row-flash 1.5s ease-out;
+}
+
+@keyframes row-flash {
+  0%   { background-color: rgba(81, 0, 205, 0.18); }
+  100% { background-color: transparent; }
+}
 </style>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import moment from 'moment'
+import dayjs from 'dayjs'
 import MessageLink from './MessageLink'
 import AddressLink from './AddressLink'
 import MessageIcon from './MessageIcon.vue'
@@ -60,10 +60,10 @@ export default {
 },
   methods: {
     dateformat (dt) {
-      return moment.unix(dt).format('lll')
+      return dayjs.unix(dt).format('lll')
     },
     reldateformat (dt) {
-      return moment.unix(dt).fromNow()
+      return dayjs.unix(dt).fromNow()
     },
     confirm_text (message) {
       let chains = [...new Set(message.confirmations.map(c => c.chain))]

--- a/src/components/MessageTable.vue
+++ b/src/components/MessageTable.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import moment from 'moment';
+import dayjs from 'dayjs';
 export default {
   name: 'MessageList',
   props: {
@@ -31,10 +31,10 @@ export default {
   },
   methods:{
     dateformat (dt) {
-      return moment.unix(dt).format('lll')
+      return dayjs.unix(dt).format('lll')
     },
     reldateformat (dt) {
-      return moment.unix(dt).fromNow()
+      return dayjs.unix(dt).fromNow()
     },
     confirm_text (message) {
       let chains = [...new Set(message.confirmations.map(c => c.chain))];

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -25,7 +25,7 @@ export default {
       } else if (/^0x[0-9a-fA-F]{40}$/.test(value)) {
         this.$router.push({ name: 'address-detail', params: { chain: 'ETH', address: value } })
       } else {
-        // Anything else — let the addresses search do substring matching.
+        // Anything else, let the addresses search do substring matching.
         this.$router.push({ name: 'addresses', query: { q: value } })
       }
     }

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,0 +1,40 @@
+<template>
+  <b-input-group class="dashboard-search">
+    <b-form-input v-model="query" placeholder="Search by item hash or address (any chain)"
+      @keyup.enter="submit" trim debounce="0" />
+    <b-input-group-append>
+      <b-button variant="primary" :disabled="!query" @click="submit">
+        <i class="fas fa-search"></i> Search
+      </b-button>
+    </b-input-group-append>
+  </b-input-group>
+</template>
+
+<script>
+export default {
+  name: 'SearchBar',
+  data() {
+    return { query: '' }
+  },
+  methods: {
+    submit() {
+      const value = (this.query || '').trim()
+      if (!value) return
+      if (/^[0-9a-fA-F]{64}$/.test(value)) {
+        this.$router.push({ name: 'message-detail', params: { hash: value } })
+      } else if (/^0x[0-9a-fA-F]{40}$/.test(value)) {
+        this.$router.push({ name: 'address-detail', params: { chain: 'ETH', address: value } })
+      } else {
+        // Anything else — let the addresses search do substring matching.
+        this.$router.push({ name: 'addresses', query: { q: value } })
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.dashboard-search {
+  margin-bottom: 1.5rem;
+}
+</style>

--- a/src/components/TaglineRotator.vue
+++ b/src/components/TaglineRotator.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="tagline-rotator">
+    <transition name="tagline-fade" mode="out-in">
+      <p :key="currentIndex" class="tagline-rotator__line">
+        {{ taglines[currentIndex] }}
+      </p>
+    </transition>
+  </div>
+</template>
+
+<script>
+const TAGLINES = [
+  'Sign with any wallet. Publish any data. Anchored on Ethereum every hour. Always free.',
+  'Permissionless publishing. Cross-chain signing. Hourly Ethereum anchoring. Zero gas for users.'
+]
+
+const ROTATE_MS = 7000
+
+export default {
+  name: 'TaglineRotator',
+  data() {
+    return {
+      taglines: TAGLINES,
+      currentIndex: 0,
+      timer: null
+    }
+  },
+  mounted() {
+    this.startRotation()
+    document.addEventListener('visibilitychange', this.onVisibilityChange)
+  },
+  beforeDestroy() {
+    this.stopRotation()
+    document.removeEventListener('visibilitychange', this.onVisibilityChange)
+  },
+  methods: {
+    startRotation() {
+      if (this.timer) return
+      this.timer = setInterval(() => {
+        this.currentIndex = (this.currentIndex + 1) % this.taglines.length
+      }, ROTATE_MS)
+    },
+    stopRotation() {
+      if (!this.timer) return
+      clearInterval(this.timer)
+      this.timer = null
+    },
+    onVisibilityChange() {
+      if (document.hidden) {
+        this.stopRotation()
+      } else {
+        this.startRotation()
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.tagline-rotator {
+  text-align: center;
+  margin: 0.5rem 0 1.5rem;
+  padding: 0 1rem;
+  min-height: 2.25em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tagline-rotator__line {
+  color: #5100cd;
+  font-size: 1.4rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.25;
+  margin: 0;
+  max-width: 56em;
+}
+
+.tagline-fade-enter-active,
+.tagline-fade-leave-active {
+  transition: opacity 0.6s ease;
+}
+
+.tagline-fade-enter,
+.tagline-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/lib/ecosystem.js
+++ b/src/lib/ecosystem.js
@@ -1,0 +1,93 @@
+/**
+ * Single source of truth for the Aleph Cloud ecosystem links.
+ * Consumed by EcosystemFooter (every page) and the /ecosystem view.
+ */
+
+export const ECOSYSTEM_GROUPS = [
+  {
+    key: 'cloud',
+    title: 'Use the cloud',
+    items: [
+      {
+        name: 'Cloud Console',
+        url: 'https://app.aleph.cloud/console/',
+        icon: 'fas fa-server',
+        tagline: 'Deploy VMs, GPU, sites & storage',
+        description:
+          'Run serverless functions, standard or GPU instances, confidential TEE VMs, ' +
+          'and host static or Next.js / React / Vue sites with custom domains.'
+      }
+    ]
+  },
+  {
+    key: 'network',
+    title: 'Run the network',
+    items: [
+      {
+        name: 'Network Overview',
+        url: 'https://network.aleph.cloud',
+        icon: 'fas fa-globe',
+        tagline: 'Live node map & metrics',
+        description:
+          'Real-time scheduler health, registered compute nodes, active VMs, and a world ' +
+          'map of the physical Aleph Cloud network distribution.'
+      },
+      {
+        name: 'Account & Staking',
+        url: 'https://app.aleph.cloud/account/',
+        icon: 'fas fa-user-shield',
+        tagline: 'Validators & rewards',
+        description:
+          'Manage core channel nodes, compute resource nodes, staking positions, and ' +
+          'monitor your reward history.'
+      }
+    ]
+  },
+  {
+    key: 'token',
+    title: 'Move ALEPH',
+    items: [
+      {
+        name: 'Bridge',
+        url: 'https://swap.aleph.cloud',
+        icon: 'fas fa-exchange-alt',
+        tagline: '$ALEPH cross-chain bridge',
+        description:
+          'Bridge $ALEPH between supported chains (Ethereum, Solana, BSC, Avalanche and more).'
+      }
+    ]
+  },
+  {
+    key: 'ai',
+    title: 'AI on Aleph',
+    items: [
+      {
+        name: 'LibertAI',
+        url: 'https://libertai.io',
+        icon: 'fas fa-robot',
+        tagline: 'Private AI, unleashed',
+        description:
+          'Private LLM inference and AI services running on decentralized Aleph Cloud ' +
+          'compute. No centralized provider holding your prompts.'
+      },
+      {
+        name: 'LiberClaw',
+        url: 'https://liberclaw.ai',
+        icon: 'fas fa-microchip',
+        tagline: 'Autonomous agents on decentralized compute',
+        description:
+          'Deploy autonomous AI agents with persistent memory and end-to-end encrypted ' +
+          'communications on the Aleph Cloud network.'
+      }
+    ]
+  }
+]
+
+export const RESOURCE_LINKS = [
+  { name: 'Aleph Cloud', url: 'https://aleph.cloud', icon: 'fas fa-home' },
+  { name: 'Documentation', url: 'https://docs.aleph.cloud/', icon: 'fas fa-book' },
+  { name: 'Blog', url: 'https://www.aleph.cloud/blog', icon: 'fas fa-rss' },
+  { name: 'GitHub', url: 'https://github.com/aleph-im', icon: 'fab fa-github' },
+  { name: 'Telegram', url: 'https://t.me/alephim/119590', icon: 'fab fa-telegram' },
+  { name: 'X (Twitter)', url: 'https://x.com/aleph_im', icon: 'fab fa-twitter' }
+]

--- a/src/lib/signature.js
+++ b/src/lib/signature.js
@@ -1,0 +1,99 @@
+/**
+ * Global signature verifier for Aleph messages.
+ *
+ * Same public API regardless of underlying implementation, so other features
+ * can build on this without caring how each chain is checked:
+ *
+ *   import { verifyMessageSignature, isChainSupported } from '@/lib/signature.js'
+ *   const result = await verifyMessageSignature(message)
+ *   // result.supported: boolean (false for chains we can't verify yet)
+ *   // result.valid    : boolean (only meaningful when supported is true)
+ *   // result.missing  : true if the message itself has no signature field
+ *   // result.chain    : normalized chain string
+ *   // result.scheme   : 'evm' | 'sol'
+ *   // result.error    : optional string when verification threw
+ *
+ * Implementation notes:
+ * - EVM (ETH, AVAX, BSC, BASE, MATIC, ARB, OP …): ethers' verifyMessage
+ *   recovers the signer from the EIP-191 personal_sign and we compare it
+ *   against the message sender.
+ * - SOL: @noble/curves ed25519.verify against the base58-decoded sender,
+ *   with fallback support for the JSON-wrapped {signature, publicKey}
+ *   format Aleph uses for some Solana clients.
+ * - TEZOS, NULS, NULS2, CSDK, DOT and friends: not yet supported.
+ *   Verifier returns `{ supported: false, chain }` so the UI can hide the
+ *   signature block instead of showing a misleading error.
+ */
+
+const EVM_CHAINS = new Set([
+  'ETH', 'AVAX', 'AVALANCHE', 'BSC', 'BNB',
+  'BASE', 'MATIC', 'POLYGON',
+  'ARB', 'ARBITRUM', 'OP', 'OPTIMISM'
+])
+
+const SOL_CHAINS = new Set(['SOL', 'SOLANA'])
+
+function buildVerificationBuffer(msg) {
+  // Aleph's canonical signable payload across all chains.
+  return msg.chain + '\n' + msg.sender + '\n' + msg.type + '\n' + msg.item_hash
+}
+
+async function verifyEvm(msg) {
+  const { verifyMessage } = await import('ethers')
+  const buffer = buildVerificationBuffer(msg)
+  const sig = msg.signature.startsWith('0x') ? msg.signature : '0x' + msg.signature
+  const recovered = verifyMessage(buffer, sig)
+  return recovered.toLowerCase() === msg.sender.toLowerCase()
+}
+
+async function verifySol(msg) {
+  const { ed25519 } = await import('@noble/curves/ed25519.js')
+  const bs58 = (await import('bs58')).default
+  const buffer = buildVerificationBuffer(msg)
+
+  // Aleph stores the Solana signature in one of two shapes:
+  //   1. a JSON object: { signature: "<base58>", publicKey: "<base58>" }
+  //   2. a raw base58 signature, with the sender used as the public key
+  let sigBytes, pubBytes
+  let parsed = null
+  try { parsed = JSON.parse(msg.signature) } catch (_e) { /* not JSON */ }
+  if (parsed && parsed.signature && parsed.publicKey) {
+    if (parsed.publicKey !== msg.sender) return false
+    sigBytes = bs58.decode(parsed.signature)
+    pubBytes = bs58.decode(parsed.publicKey)
+  } else {
+    sigBytes = bs58.decode(msg.signature)
+    pubBytes = bs58.decode(msg.sender)
+  }
+  const msgBytes = new TextEncoder().encode(buffer)
+  return ed25519.verify(sigBytes, msgBytes, pubBytes)
+}
+
+export function isChainSupported(chain) {
+  const c = String(chain || '').toUpperCase()
+  return EVM_CHAINS.has(c) || SOL_CHAINS.has(c)
+}
+
+export async function verifyMessageSignature(message) {
+  if (!message || !message.chain) {
+    return { supported: false, valid: false, error: 'Message has no chain field.' }
+  }
+  if (!message.signature) {
+    return { supported: true, valid: false, missing: true,
+      error: 'Message has no signature field.' }
+  }
+
+  const chain = String(message.chain).toUpperCase()
+  let scheme, verifier
+  if (EVM_CHAINS.has(chain)) { scheme = 'evm'; verifier = verifyEvm }
+  else if (SOL_CHAINS.has(chain)) { scheme = 'sol'; verifier = verifySol }
+  else return { supported: false, chain }
+
+  try {
+    const valid = await verifier(message)
+    return { supported: true, valid: Boolean(valid), chain, scheme }
+  } catch (err) {
+    return { supported: true, valid: false, chain, scheme,
+      error: err && err.message ? err.message : String(err) }
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,17 +2,53 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
-import BootstrapVue from 'bootstrap-vue'
 import vSelect from 'vue-select'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
+import {
+  BBadge,
+  BButton,
+  BCard, BCardBody, BCardFooter, BCardHeader, BCardText,
+  BCol, BContainer, BRow,
+  BFormGroup, BFormInput, BFormRadio, BFormRadioGroup,
+  BInputGroup, BInputGroupAppend,
+  BLink,
+  BListGroup, BListGroupItem,
+  BNav, BNavbar, BNavbarBrand, BNavItem,
+  BPagination,
+  BSpinner,
+  BTab, BTable, BTabs,
+  BToast,
+  VBTooltip
+} from 'bootstrap-vue'
+
 dayjs.extend(localizedFormat)
 dayjs.extend(relativeTime)
 
+// Register only the bootstrap-vue components actually used in templates.
+// Adding a new <b-*> tag requires adding it to this list.
+const bootstrapVueComponents = {
+  BBadge,
+  BButton,
+  BCard, BCardBody, BCardFooter, BCardHeader, BCardText,
+  BCol, BContainer, BRow,
+  BFormGroup, BFormInput, BFormRadio, BFormRadioGroup,
+  BInputGroup, BInputGroupAppend,
+  BLink,
+  BListGroup, BListGroupItem,
+  BNav, BNavbar, BNavbarBrand, BNavItem,
+  BPagination,
+  BSpinner,
+  BTab, BTable, BTabs,
+  BToast
+}
+for (const [name, component] of Object.entries(bootstrapVueComponents)) {
+  Vue.component(name, component)
+}
+Vue.directive('b-tooltip', VBTooltip)
 Vue.component('v-select', vSelect)
-Vue.use(BootstrapVue)
 
 Vue.config.productionTip = false
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,12 @@ import router from './router'
 import store from './store'
 import BootstrapVue from 'bootstrap-vue'
 import vSelect from 'vue-select'
+import dayjs from 'dayjs'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+dayjs.extend(localizedFormat)
+dayjs.extend(relativeTime)
 
 Vue.component('v-select', vSelect)
 Vue.use(BootstrapVue)

--- a/src/router.js
+++ b/src/router.js
@@ -43,6 +43,11 @@ export default new Router({
       path: '/addresses',
       name: 'addresses',
       component: () => import('./views/Addresses.vue')
+    },
+    {
+      path: '/ecosystem',
+      name: 'ecosystem',
+      component: () => import('./views/Ecosystem.vue')
     }
   ]
 })

--- a/src/router.js
+++ b/src/router.js
@@ -50,9 +50,10 @@ export default new Router({
       component: () => import('./views/Ecosystem.vue')
     },
     {
-      path: '/verify',
+      path: '/verify/:hash?',
       name: 'verify',
-      component: () => import('./views/Verify.vue')
+      component: () => import('./views/Verify.vue'),
+      props: true
     }
   ]
 })

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,11 @@ export default new Router({
       path: '/ecosystem',
       name: 'ecosystem',
       component: () => import('./views/Ecosystem.vue')
+    },
+    {
+      path: '/verify',
+      name: 'verify',
+      component: () => import('./views/Verify.vue')
     }
   ]
 })

--- a/src/store.js
+++ b/src/store.js
@@ -37,6 +37,11 @@ export default new Vuex.Store({
     last_broadcast: null,
     channels: [],
     channels_loaded_for: null,
+    metrics: null,
+    metrics_observed_at: null,
+    eth_block_observed_at: null,
+    eth_block_committed_at: null,
+    message_rates: { h1: null, h24: null },
     api_server: {
       host: 'api2.aleph.im',
       protocol: 'https:',
@@ -114,9 +119,76 @@ export default new Vuex.Store({
     set_channels (state, payload) {
       state.channels = payload.channels
       state.channels_loaded_for = payload.host
+    },
+    set_metrics (state, payload) {
+      const previousHeight = state.metrics
+        && state.metrics.pyaleph_status_chain_eth_last_committed_height
+      const newHeight = payload && payload.pyaleph_status_chain_eth_last_committed_height
+      // Wall-clock fallback used by the countdown if the RPC lookup fails.
+      // Reset only when the height actually advances so the countdown survives
+      // intermediate metrics polls.
+      if (newHeight !== undefined && newHeight !== previousHeight) {
+        state.eth_block_observed_at = Date.now()
+      }
+      state.metrics = payload
+      state.metrics_observed_at = Date.now()
+    },
+    set_eth_block_committed_at (state, timestamp) {
+      state.eth_block_committed_at = timestamp
+    },
+    set_message_rates (state, payload) {
+      state.message_rates = payload
     }
   },
   actions: {
+    async load_metrics({commit, dispatch, state}) {
+      try {
+        const previousHeight = state.metrics
+          && state.metrics.pyaleph_status_chain_eth_last_committed_height
+        const { data } = await axios.get(
+          `${state.api_server.protocol}//${state.api_server.host}/metrics.json`
+        )
+        commit('set_metrics', data)
+        const newHeight = data && data.pyaleph_status_chain_eth_last_committed_height
+        if (newHeight !== undefined && newHeight !== previousHeight) {
+          dispatch('load_eth_block_timestamp', newHeight)
+        }
+      } catch (error) {
+        console.error('Failed to fetch metrics:', error)
+      }
+    },
+    async load_eth_block_timestamp({commit}, height) {
+      try {
+        const hex = '0x' + height.toString(16)
+        const { data } = await axios.post('https://ethereum-rpc.publicnode.com', {
+          jsonrpc: '2.0',
+          method: 'eth_getBlockByNumber',
+          params: [hex, false],
+          id: 1
+        })
+        const tsHex = data && data.result && data.result.timestamp
+        if (!tsHex) return
+        commit('set_eth_block_committed_at', parseInt(tsHex, 16) * 1000)
+      } catch (error) {
+        console.error('Failed to fetch ETH block timestamp:', error)
+      }
+    },
+    async load_message_rates({commit, state}) {
+      const now = Math.floor(Date.now() / 1000)
+      const baseUrl = `${state.api_server.protocol}//${state.api_server.host}/api/v0/messages.json`
+      try {
+        const [h1, h24] = await Promise.all([
+          axios.get(baseUrl, { params: { startDate: now - 3600, pagination: 1, page: 1 } }),
+          axios.get(baseUrl, { params: { startDate: now - 86400, pagination: 1, page: 1 } })
+        ])
+        commit('set_message_rates', {
+          h1: h1.data.pagination_total ?? null,
+          h24: h24.data.pagination_total ?? null
+        })
+      } catch (error) {
+        console.error('Failed to fetch message rates:', error)
+      }
+    },
     async load_channels({commit, state}) {
       if (state.channels_loaded_for === state.api_server.host) return
       try {

--- a/src/store.js
+++ b/src/store.js
@@ -42,6 +42,7 @@ export default new Vuex.Store({
     eth_block_observed_at: null,
     eth_block_committed_at: null,
     message_rates: { h1: null, h24: null },
+    network: { ccn_count: null, observed_at: null },
     api_server: {
       host: 'api2.aleph.im',
       protocol: 'https:',
@@ -138,6 +139,9 @@ export default new Vuex.Store({
     },
     set_message_rates (state, payload) {
       state.message_rates = payload
+    },
+    set_network_size (state, payload) {
+      state.network = { ...payload, observed_at: Date.now() }
     }
   },
   actions: {
@@ -155,6 +159,30 @@ export default new Vuex.Store({
         }
       } catch (error) {
         console.error('Failed to fetch metrics:', error)
+      }
+    },
+    async load_network_size({commit, state}) {
+      // The canonical corechannel aggregate is published by the Aleph
+      // foundation address. Other addresses also have corechannel entries,
+      // so we filter explicitly to avoid picking the wrong one.
+      try {
+        const { data } = await axios.get(
+          `${state.api_server.protocol}//${state.api_server.host}/api/v0/aggregates`,
+          {
+            params: {
+              keys: 'corechannel',
+              addresses: '0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10',
+              pagination: 1
+            }
+          }
+        )
+        const agg = data && data.aggregates && data.aggregates[0]
+        const nodes = agg && agg.content && agg.content.nodes
+        if (Array.isArray(nodes)) {
+          commit('set_network_size', { ccn_count: nodes.length })
+        }
+      } catch (error) {
+        console.error('Failed to fetch network size:', error)
       }
     },
     async load_eth_block_timestamp({commit}, height) {

--- a/src/store.js
+++ b/src/store.js
@@ -35,6 +35,8 @@ export default new Vuex.Store({
     },
     api_version: 'v1',
     last_broadcast: null,
+    channels: [],
+    channels_loaded_for: null,
     api_server: {
       host: 'api2.aleph.im',
       protocol: 'https:',
@@ -108,9 +110,26 @@ export default new Vuex.Store({
     },
     set_address_posts_pagination (state, pagination) {
       state.address_detail.posts_pagination = pagination
+    },
+    set_channels (state, payload) {
+      state.channels = payload.channels
+      state.channels_loaded_for = payload.host
     }
   },
   actions: {
+    async load_channels({commit, state}) {
+      if (state.channels_loaded_for === state.api_server.host) return
+      try {
+        const response = await axios.get(
+          `${state.api_server.protocol}//${state.api_server.host}/api/v0/channels/list.json`
+        )
+        const channels = (response.data.channels || []).filter(c => c != null)
+        commit('set_channels', { channels, host: state.api_server.host })
+      } catch (error) {
+        console.error('Failed to fetch channels:', error)
+        commit('set_channels', { channels: [], host: state.api_server.host })
+      }
+    },
     async load_addresses({commit, state}, payload = {}) {
       try {
         const {

--- a/src/store.js
+++ b/src/store.js
@@ -142,22 +142,14 @@ export default new Vuex.Store({
     },
     async load_address_stats({commit, state}, address) {
       try {
-        // Use our helper function to get address stats with exact address matching
+        // A full-length address as the substring filter matches at most itself,
+        // so a single-row page is enough to find it (or confirm it's absent).
         const result = await fetchAddresses(state.api_server, {
           addressContains: address,
-          perPage: 20  // Get enough addresses to ensure we find the one we're looking for
+          perPage: 1
         });
-
-        // Find the exact match for this address
-        const addressItem = Object.values(result.addressesObject)
-          .find(item => item.address === address);
-
-        if (addressItem) {
-          commit("set_address_stats", addressItem);
-        } else {
-          // If no exact match found, set empty stats
-          commit("set_address_stats", {});
-        }
+        const [addressItem] = Object.values(result.addressesObject);
+        commit("set_address_stats", addressItem || {});
       } catch (error) {
         console.error("Failed to get address stats:", error);
         commit("set_address_stats", {});

--- a/src/store.js
+++ b/src/store.js
@@ -235,7 +235,6 @@ export default new Vuex.Store({
             `${state.api_server.protocol}//${state.api_server.host}/api/v1/posts.json`,
             {
               params: {
-                'types': 'blog_pers,comment,social',
                 'addresses': address,
                 'pagination': perPage,
                 'page': page

--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -40,11 +40,11 @@
               </div>
               <div class="profile-widget-item">
                 <div class="profile-widget-item-label">Posts</div>
-                <div class="profile-widget-item-value">{{stats.posts || 0}}</div>
+                <div class="profile-widget-item-value">{{stats.post || 0}}</div>
               </div>
               <div class="profile-widget-item">
                 <div class="profile-widget-item-label">Aggregates</div>
-                <div class="profile-widget-item-value">{{stats.aggregates || 0}}</div>
+                <div class="profile-widget-item-value">{{stats.aggregate || 0}}</div>
               </div>
             </div>
           </div>

--- a/src/views/AddressDetail.vue
+++ b/src/views/AddressDetail.vue
@@ -149,6 +149,23 @@ export default {
     onMessagesPageChange(newPage) {
       this.current_msg_page = newPage
       this.refreshMessages()
+    },
+    startPolling() {
+      if (this.polling) return
+      this.polling = setInterval(this.partialRefresh, 10000)
+    },
+    stopPolling() {
+      if (!this.polling) return
+      clearInterval(this.polling)
+      this.polling = null
+    },
+    onVisibilityChange() {
+      if (document.hidden) {
+        this.stopPolling()
+      } else {
+        this.partialRefresh()
+        this.startPolling()
+      }
     }
   },
   watch: {
@@ -160,11 +177,12 @@ export default {
     this.loadAllData()
   },
   mounted() {
-    // Set up polling to refresh messages and posts data
-    this.polling = setInterval(this.partialRefresh.bind(this), 10000)
+    this.startPolling()
+    document.addEventListener('visibilitychange', this.onVisibilityChange)
   },
   beforeDestroy () {
-  	clearInterval(this.polling)
+    this.stopPolling()
+    document.removeEventListener('visibilitychange', this.onVisibilityChange)
   }
 }
 </script>

--- a/src/views/Addresses.vue
+++ b/src/views/Addresses.vue
@@ -1,17 +1,19 @@
 <template>
   <div>
     <b-card no-body class="card-primary">
-      <b-card-header class="d-flex justify-content-between">
-        <h4>Addresses <b-spinner small class="ml-3" label="Loading addresses" v-if="is_loading" /></h4>
+      <b-card-header class="d-flex align-items-center flex-wrap">
+        <h4 class="mb-0 mr-3">
+          Addresses <b-spinner small class="ml-3" label="Loading addresses" v-if="is_loading" />
+        </h4>
 
-        <b-form-group label-cols-sm="3" class="mb-0">
-          <b-input-group>
-            <b-form-input v-model="filter" placeholder="Search by address"></b-form-input>
-            <b-input-group-append>
-              <b-button :disabled="!filter" @click="clearFilter" class="clear-button">Clear</b-button>
-            </b-input-group-append>
-          </b-input-group>
-        </b-form-group>
+        <b-input-group class="addresses-search ml-auto">
+          <b-form-input v-model="filter" placeholder="Search by address" />
+          <b-input-group-append>
+            <b-button variant="primary" :disabled="!filter" @click="clearFilter">
+              <i class="fas fa-times"></i> Clear
+            </b-button>
+          </b-input-group-append>
+        </b-input-group>
       </b-card-header>
 
       <!-- Table implementation for addresses -->
@@ -190,5 +192,11 @@ export default {
   opacity: 0.2;
   pointer-events: none;
   transition: opacity 0.2s;
+}
+
+.addresses-search {
+  flex: 1 1 auto;
+  max-width: 480px;
+  min-width: 240px;
 }
 </style>

--- a/src/views/Addresses.vue
+++ b/src/views/Addresses.vue
@@ -19,7 +19,7 @@
       <!-- Table implementation for addresses -->
       <b-table responsive table-class="compact mb-0 addresses-table"
         :class="{ 'is-loading-data': is_loading }"
-        :items="items" :fields="addresses_fields" stacked="sm"
+        :items="items" :fields="addresses_fields"
         :sort-by.sync="sortBy" :sort-desc.sync="sortDesc" @sort-changed="loadAddresses">
         <template v-slot:cell(address)="data">
           <AddressLink :address="data.value" class="address" />
@@ -28,8 +28,11 @@
 
       <b-card-footer class="d-flex justify-content-between align-items-center bg-whitesmoke">
         <span>Total: {{ total }}</span>
-        <b-pagination v-model="page" :total-rows="total" :per-page="per_page" limit="9" class="mb-0"
-          size="sm" @change="changePage">
+        <b-pagination v-model="page" :total-rows="total" :per-page="per_page" limit="9"
+          class="mb-0 d-none d-md-inline-flex" size="sm" @change="changePage">
+        </b-pagination>
+        <b-pagination v-model="page" :total-rows="total" :per-page="per_page" limit="3"
+          class="mb-0 d-md-none" size="sm" @change="changePage">
         </b-pagination>
       </b-card-footer>
       <!--

--- a/src/views/Addresses.vue
+++ b/src/views/Addresses.vue
@@ -2,7 +2,7 @@
   <div>
     <b-card no-body class="card-primary">
       <b-card-header class="d-flex justify-content-between">
-        <h4>Addresses</h4>
+        <h4>Addresses <b-spinner small class="ml-3" label="Loading addresses" v-if="is_loading" /></h4>
 
         <b-form-group label-cols-sm="3" class="mb-0">
           <b-input-group>
@@ -15,7 +15,9 @@
       </b-card-header>
 
       <!-- Table implementation for addresses -->
-      <b-table responsive table-class="compact" :items="items" :fields="addresses_fields" stacked="sm"
+      <b-table responsive table-class="compact mb-0 addresses-table"
+        :class="{ 'is-loading-data': is_loading }"
+        :items="items" :fields="addresses_fields" stacked="sm"
         :sort-by.sync="sortBy" :sort-desc.sync="sortDesc" @sort-changed="loadAddresses">
         <template v-slot:cell(address)="data">
           <AddressLink :address="data.value" class="address" />
@@ -57,6 +59,7 @@ export default {
         { key: 'total', label: 'Total Messages', class: 'text-right', sortable: true, sortDirection: 'desc' }
       ],
       filterDebounceTimer: null,
+      is_loading: false,
     }
   },
   computed: {
@@ -89,16 +92,19 @@ export default {
     AddressLink
   },
   methods: {
-    loadAddresses() {
-        this.$store.dispatch("load_addresses", {
+    async loadAddresses() {
+      this.is_loading = true
+      try {
+        await this.$store.dispatch("load_addresses", {
           page: this.page,
           perPage: this.per_page,
           sortBy: this.sortBy,
           sortOrder: this.sortDesc ? -1 : 1,
           addressContains: this.filter
         })
-
-
+      } finally {
+        this.is_loading = false
+      }
     },
 
     onFilterUpdate() {
@@ -155,3 +161,34 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+/* Match the Home dashboard table style. ::v-deep is needed because
+   b-table renders thead/tbody internally, outside the scoped attr. */
+::v-deep .addresses-table thead th {
+  padding: 0.55rem 1.25rem !important;
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  color: #000 !important;
+  text-transform: none !important;
+  background: transparent !important;
+  border-bottom: 1px solid #dee2e6 !important;
+}
+
+::v-deep .addresses-table tbody td {
+  height: auto !important;
+  padding: 0.5rem 1.25rem !important;
+  vertical-align: middle;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+::v-deep .addresses-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.is-loading-data {
+  opacity: 0.2;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+</style>

--- a/src/views/Addresses.vue
+++ b/src/views/Addresses.vue
@@ -140,6 +140,11 @@ export default {
     this.page = this.addresses_pagination.page || 1;
     this.per_page = this.addresses_pagination.per_page || 20;
 
+    // Seed the search box from ?q=… so links from SearchBar land pre-filtered.
+    if (this.$route.query.q) {
+      this.filter = this.$route.query.q;
+    }
+
     // Always load first page data to ensure it's fresh
     this.loadAddresses();
   },

--- a/src/views/Addresses.vue
+++ b/src/views/Addresses.vue
@@ -16,7 +16,7 @@
 
       <!-- Table implementation for addresses -->
       <b-table responsive table-class="compact" :items="items" :fields="addresses_fields" stacked="sm"
-        :sort-by.sync="sortBy" :sort-desc.sync="sortDesc">
+        :sort-by.sync="sortBy" :sort-desc.sync="sortDesc" @sort-changed="loadAddresses">
         <template v-slot:cell(address)="data">
           <AddressLink :address="data.value" class="address" />
         </template>
@@ -130,12 +130,6 @@ export default {
       if (newPage !== oldPage) {
         this.loadAddresses();
       }
-    },
-    sortBy() {
-      this.loadAddresses();
-    },
-    sortDesc() {
-      this.loadAddresses();
     },
     filter() {
       this.onFilterUpdate();

--- a/src/views/Ecosystem.vue
+++ b/src/views/Ecosystem.vue
@@ -10,6 +10,22 @@
         Below is the rest of what the Aleph&nbsp;Cloud teams ship; pick a card to jump in.
       </p>
 
+      <b-card no-body class="ecosystem-redundancy mb-4">
+        <b-card-body>
+          <div class="d-flex align-items-center flex-wrap">
+            <i class="fas fa-shield-alt ecosystem-redundancy__icon"></i>
+            <div class="ml-3 flex-grow-1">
+              <div class="ecosystem-redundancy__label">Storage redundancy</div>
+              <p class="ecosystem-redundancy__text mb-0">
+                Every file pinned on Aleph is replicated across
+                <strong>{{ ccnCount }} Core&nbsp;Channel Nodes</strong> worldwide. No single
+                node, region or operator can take your data offline.
+              </p>
+            </div>
+          </div>
+        </b-card-body>
+      </b-card>
+
       <div v-for="group in groups" :key="group.key" class="ecosystem-group">
         <h3 class="ecosystem-group__title">{{ group.title }}</h3>
         <b-row>
@@ -50,6 +66,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import { ECOSYSTEM_GROUPS, RESOURCE_LINKS } from '@/lib/ecosystem.js'
 
 export default {
@@ -58,6 +75,22 @@ export default {
     return {
       groups: ECOSYSTEM_GROUPS,
       resources: RESOURCE_LINKS
+    }
+  },
+  computed: {
+    ...mapState({
+      network: state => state.network
+    }),
+    ccnCount() {
+      const n = this.network && this.network.ccn_count
+      return n != null ? Number(n).toLocaleString('en-US') : '—'
+    }
+  },
+  created() {
+    // Same data source as the dashboard card; safe to dispatch even if the
+    // user lands directly here (action no-ops cheaply when in flight).
+    if (!this.network || this.network.ccn_count == null) {
+      this.$store.dispatch('load_network_size')
     }
   }
 }
@@ -71,6 +104,37 @@ export default {
   color: #2b1865;
   margin-bottom: 2rem;
   max-width: 50em;
+}
+
+.ecosystem-redundancy {
+  border: 1px solid rgba(81, 0, 205, 0.15);
+  background: linear-gradient(135deg, rgba(81, 0, 205, 0.04), rgba(212, 255, 0, 0.05));
+}
+
+.ecosystem-redundancy__icon {
+  font-size: 2rem;
+  color: #5100cd;
+  flex: 0 0 auto;
+}
+
+.ecosystem-redundancy__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6c757d;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.ecosystem-redundancy__text {
+  color: #2b1865;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.ecosystem-redundancy__text strong {
+  color: #5100cd;
+  font-weight: 700;
 }
 
 .ecosystem-group {

--- a/src/views/Ecosystem.vue
+++ b/src/views/Ecosystem.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
     <div class="section-header">
-      <h1>The Aleph Cloud ecosystem</h1>
+      <h1>The Aleph&nbsp;Cloud ecosystem</h1>
     </div>
     <div class="section-body">
       <p class="ecosystem-lead">
         The explorer you're looking at is one slice of a much bigger network.
-        Below is the rest of what the Aleph Cloud teams ship; pick a card to jump in.
+        <br />
+        Below is the rest of what the Aleph&nbsp;Cloud teams ship; pick a card to jump in.
       </p>
 
       <div v-for="group in groups" :key="group.key" class="ecosystem-group">
@@ -64,10 +65,12 @@ export default {
 
 <style scoped>
 .ecosystem-lead {
-  font-size: 0.95rem;
-  color: #6c757d;
-  margin-bottom: 1.5rem;
-  max-width: 60em;
+  font-size: 1.35rem;
+  font-weight: 400;
+  line-height: 1.4;
+  color: #2b1865;
+  margin-bottom: 2rem;
+  max-width: 50em;
 }
 
 .ecosystem-group {

--- a/src/views/Ecosystem.vue
+++ b/src/views/Ecosystem.vue
@@ -1,0 +1,145 @@
+<template>
+  <div>
+    <div class="section-header">
+      <h1>The Aleph Cloud ecosystem</h1>
+    </div>
+    <div class="section-body">
+      <p class="ecosystem-lead">
+        The explorer you're looking at is one slice of a much bigger network.
+        Below is the rest of what the Aleph Cloud teams ship; pick a card to jump in.
+      </p>
+
+      <div v-for="group in groups" :key="group.key" class="ecosystem-group">
+        <h3 class="ecosystem-group__title">{{ group.title }}</h3>
+        <b-row>
+          <b-col v-for="item in group.items" :key="item.name" cols="12" md="6" lg="4" class="mb-3">
+            <b-card no-body class="ecosystem-card h-100">
+              <b-card-body class="d-flex flex-column">
+                <div class="d-flex align-items-center mb-2">
+                  <span class="ecosystem-card__icon"><i :class="item.icon"></i></span>
+                  <div class="ml-3">
+                    <div class="ecosystem-card__name">{{ item.name }}</div>
+                    <div class="ecosystem-card__tagline">{{ item.tagline }}</div>
+                  </div>
+                </div>
+                <p class="ecosystem-card__description">{{ item.description }}</p>
+                <a :href="item.url" target="_blank" rel="noopener noreferrer"
+                  class="btn btn-primary btn-sm mt-auto align-self-start">
+                  Open <i class="fas fa-external-link-alt fa-xs ml-1"></i>
+                </a>
+              </b-card-body>
+            </b-card>
+          </b-col>
+        </b-row>
+      </div>
+
+      <b-card no-body class="ecosystem-resources">
+        <b-card-body>
+          <h3 class="mb-3">Resources & community</h3>
+          <div class="d-flex flex-wrap">
+            <a v-for="link in resources" :key="link.name" :href="link.url" target="_blank"
+              rel="noopener noreferrer" class="ecosystem-resource">
+              <i :class="link.icon"></i> {{ link.name }}
+            </a>
+          </div>
+        </b-card-body>
+      </b-card>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ECOSYSTEM_GROUPS, RESOURCE_LINKS } from '@/lib/ecosystem.js'
+
+export default {
+  name: 'ecosystem',
+  data() {
+    return {
+      groups: ECOSYSTEM_GROUPS,
+      resources: RESOURCE_LINKS
+    }
+  }
+}
+</script>
+
+<style scoped>
+.ecosystem-lead {
+  font-size: 0.95rem;
+  color: #6c757d;
+  margin-bottom: 1.5rem;
+  max-width: 60em;
+}
+
+.ecosystem-group {
+  margin-bottom: 1.5rem;
+}
+
+.ecosystem-group__title {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #5100cd;
+  margin-bottom: 0.75rem;
+}
+
+.ecosystem-card {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.ecosystem-card:hover {
+  box-shadow: 0 6px 18px rgba(81, 0, 205, 0.08);
+  transform: translateY(-1px);
+}
+
+.ecosystem-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.5rem;
+  background: rgba(81, 0, 205, 0.08);
+  color: #5100cd;
+  font-size: 1.1rem;
+  flex: 0 0 auto;
+}
+
+.ecosystem-card__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.ecosystem-card__tagline {
+  font-size: 0.8rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+}
+
+.ecosystem-card__description {
+  font-size: 0.85rem;
+  color: #495057;
+  margin-bottom: 1rem;
+  flex-grow: 1;
+}
+
+.ecosystem-resources {
+  margin-top: 1rem;
+}
+
+.ecosystem-resource {
+  color: #495057;
+  text-decoration: none;
+  font-size: 0.9rem;
+  margin: 0 1.25rem 0.5rem 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ecosystem-resource:hover {
+  color: #5100cd;
+}
+</style>

--- a/src/views/Ecosystem.vue
+++ b/src/views/Ecosystem.vue
@@ -49,32 +49,19 @@
           </b-col>
         </b-row>
       </div>
-
-      <b-card no-body class="ecosystem-resources">
-        <b-card-body>
-          <h3 class="mb-3">Resources & community</h3>
-          <div class="d-flex flex-wrap">
-            <a v-for="link in resources" :key="link.name" :href="link.url" target="_blank"
-              rel="noopener noreferrer" class="ecosystem-resource">
-              <i :class="link.icon"></i> {{ link.name }}
-            </a>
-          </div>
-        </b-card-body>
-      </b-card>
     </div>
   </div>
 </template>
 
 <script>
 import { mapState } from 'vuex'
-import { ECOSYSTEM_GROUPS, RESOURCE_LINKS } from '@/lib/ecosystem.js'
+import { ECOSYSTEM_GROUPS } from '@/lib/ecosystem.js'
 
 export default {
   name: 'ecosystem',
   data() {
     return {
-      groups: ECOSYSTEM_GROUPS,
-      resources: RESOURCE_LINKS
+      groups: ECOSYSTEM_GROUPS
     }
   },
   computed: {
@@ -192,21 +179,5 @@ export default {
   flex-grow: 1;
 }
 
-.ecosystem-resources {
-  margin-top: 1rem;
-}
 
-.ecosystem-resource {
-  color: #495057;
-  text-decoration: none;
-  font-size: 0.9rem;
-  margin: 0 1.25rem 0.5rem 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.ecosystem-resource:hover {
-  color: #5100cd;
-}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -52,6 +52,8 @@ export default {
     return {
       last_messages: [],
       message_socket: null,
+      reconnectTimer: null,
+      reconnectDelay: 1000,
       messages_fields: [
         { key: 'item_hash', label: 'Item Hash', class: 'hash' },
         { key: 'type', label: 'Type' },
@@ -104,14 +106,18 @@ export default {
     },
     openWS() {
       const socket = new WebSocket(`${this.api_server.ws_protocol}//${this.api_server.host}/api/ws0/messages?history=${QUEUE_SIZE}`)
+      socket._intentionallyClosed = false
 
       // Batch the firsts messages in a dedicated queue
       // so the "MessageList" component only updates once it is filled
       const prefillQueue = []
       this.last_messages = []
       this.query_status.is_loading = true
+      this.query_status.has_error = false
 
       socket.addEventListener('message', (e) => {
+        // First message proves the connection is healthy — reset backoff.
+        this.reconnectDelay = 1000
         let data
         try {
           this.query_status.is_loading = false
@@ -120,6 +126,7 @@ export default {
             return
         } catch (error) {
           console.log('Could not parse socket response')
+          return
         }
 
         if (this.last_messages.length === QUEUE_SIZE)
@@ -131,7 +138,30 @@ export default {
       })
 
       socket.addEventListener('error', () => this.query_status.has_error = true)
+      socket.addEventListener('close', () => {
+        if (socket._intentionallyClosed) return
+        this.scheduleReconnect()
+      })
       this.message_socket = socket
+    },
+    scheduleReconnect() {
+      if (this.reconnectTimer) return
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null
+        this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000)
+        this.openWS()
+      }, this.reconnectDelay)
+    },
+    closeWS() {
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer)
+        this.reconnectTimer = null
+      }
+      if (this.message_socket) {
+        this.message_socket._intentionallyClosed = true
+        this.message_socket.close()
+        this.message_socket = null
+      }
     }
   },
   mounted() {
@@ -145,14 +175,13 @@ export default {
   },
   watch: {
     'api_server.host'() {
-      if (this.message_socket)
-        this.message_socket.close()
-
+      this.closeWS()
+      this.reconnectDelay = 1000
       this.openWS()
     }
   },
   beforeDestroy() {
-    this.message_socket.close()
+    this.closeWS()
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -7,24 +7,31 @@
         <b-col cols="12" md="6">
           <b-card no-body>
             <b-card-header>
-              <h4>Last messages <b-spinner small class="ml-3" label="Loading messages" v-if="query_status.is_loading" />
-              </h4>
+              <h4>Last messages <b-spinner small class="ml-3" label="Loading messages"
+                v-if="query_status.is_loading" /></h4>
               <div class="card-header-action">
                 <b-link class="btn btn-primary" to="/messages">View all <i class="fas fa-chevron-right"></i></b-link>
               </div>
             </b-card-header>
+            <div class="messages-list-header">
+              <span class="col-hash">#</span>
+              <span class="col-subtype ml-auto d-none d-xl-block">Sub Type / Key</span>
+              <span class="col-confirmed ml-auto">Confirmed</span>
+            </div>
             <MessageList :messages="last_messages" class="compact" animate />
           </b-card>
         </b-col>
         <b-col cols="12" md="6">
           <b-card no-body>
             <b-card-header>
-              <h4>Most active addresses</h4>
+              <h4>Most active addresses <b-spinner small class="ml-3" label="Loading addresses"
+                v-if="addresses_loading" /></h4>
               <div class="card-header-action">
                 <b-link class="btn btn-primary" to="/addresses">View all <i class="fas fa-chevron-right"></i></b-link>
               </div>
             </b-card-header>
-            <b-table responsive table-class="compact" :items="active_addresses" :fields="addresses_fields">
+            <b-table responsive table-class="compact home-addresses-table" :items="active_addresses"
+              :fields="addresses_fields">
               <template slot="address" slot-scope="data">
                 <AddressLink :address="data.item.address" class="address break-xs" />
               </template>
@@ -43,7 +50,6 @@
 import { mapState } from 'vuex'
 import dayjs from 'dayjs'
 import MessageList from '@/components/MessageList.vue'
-import MessageTable from '@/components/MessageTable.vue'
 import AddressLink from '@/components/AddressLink'
 import DashboardStats from '@/components/DashboardStats.vue'
 
@@ -59,6 +65,7 @@ export default {
       reconnectDelay: 1000,
       metricsTimer: null,
       ratesTimer: null,
+      addresses_loading: false,
       messages_fields: [
         { key: 'item_hash', label: 'Item Hash', class: 'hash' },
         { key: 'type', label: 'Type' },
@@ -91,7 +98,6 @@ export default {
   },
   components: {
     MessageList,
-    MessageTable,
     AddressLink,
     DashboardStats
   },
@@ -193,12 +199,13 @@ export default {
   },
   mounted() {
     this.openWS()
+    this.addresses_loading = true
     this.$store.dispatch('load_addresses', {
       page: 1,
       perPage: 25,
       sortBy: 'total',
       sortOrder: -1
-    })
+    }).finally(() => { this.addresses_loading = false })
     this.startDashboardPolling()
     document.addEventListener('visibilitychange', this.onVisibilityChange)
   },
@@ -219,5 +226,48 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.messages-list-header {
+  display: flex;
+  align-items: center;
+  padding: 0.55rem 1.25rem;
+  font-size: 0.75rem;
+  font-weight: 700 !important;
+  color: #000;
+  text-transform: none;
+  background: transparent;
+  border-bottom: 1px solid #dee2e6;
+}
 
+.messages-list-header .col-hash {
+  flex: 0 0 50%;
+}
+
+.messages-list-header .col-confirmed {
+  text-align: right;
+}
+
+/* Match the messages-list-header look on the addresses table thead.
+   ::v-deep is needed because the b-table renders thead/th internally,
+   outside the scoped data-attribute. */
+::v-deep .home-addresses-table thead th {
+  padding: 0.55rem 1.25rem !important;
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  color: #000 !important;
+  text-transform: none !important;
+  background: transparent !important;
+  border-bottom: 1px solid #dee2e6 !important;
+}
+
+/* Match MessageList row padding + border on the addresses table body. */
+::v-deep .home-addresses-table tbody td {
+  height: auto !important;
+  padding: 0.5rem 1.25rem !important;
+  vertical-align: middle;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+::v-deep .home-addresses-table tbody tr:last-child td {
+  border-bottom: none;
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,8 +9,20 @@
         <b-col cols="12" md="6">
           <b-card no-body>
             <b-card-header>
-              <h4>Last messages <b-spinner small class="ml-3" label="Loading messages"
-                v-if="query_status.is_loading" /></h4>
+              <h4 class="d-flex align-items-center flex-wrap mb-0">
+                <span class="mr-2">Last messages</span>
+                <span class="ws-status" :class="wsStatusClass"
+                  v-b-tooltip.hover :title="wsStatusTitle">
+                  <span class="ws-status__dot"></span>
+                </span>
+                <b-badge v-if="!query_status.has_error" variant="light"
+                  class="ws-rate ml-2" v-b-tooltip.hover
+                  title="Messages received in this tab over the last 5 minutes">
+                  +{{ recentTimes.length }} /5min
+                </b-badge>
+                <b-spinner small class="ml-3" label="Loading messages"
+                  v-if="query_status.is_loading" />
+              </h4>
               <div class="card-header-action">
                 <b-link class="btn btn-primary" to="/messages">View all <i class="fas fa-chevron-right"></i></b-link>
               </div>
@@ -69,6 +81,8 @@ export default {
       metricsTimer: null,
       ratesTimer: null,
       addresses_loading: false,
+      recentTimes: [],
+      rateTickTimer: null,
       messages_fields: [
         { key: 'item_hash', label: 'Item Hash', class: 'hash' },
         { key: 'type', label: 'Type' },
@@ -91,6 +105,16 @@ export default {
       return Object.entries(this.addresses_stats)
         .map(([address, stats]) => ({ address, ...stats }))
         .sort((a, b) => b.messages - a.messages).slice(0, 25)
+    },
+    wsStatusClass() {
+      if (this.query_status.has_error) return 'ws-status--error'
+      if (this.query_status.is_loading) return 'ws-status--connecting'
+      return 'ws-status--live'
+    },
+    wsStatusTitle() {
+      if (this.query_status.has_error) return 'Live stream disconnected'
+      if (this.query_status.is_loading) return 'Connecting to live stream…'
+      return 'Live stream connected'
     },
     ...mapState({
       account: 'account',
@@ -120,6 +144,18 @@ export default {
       this.last_messages.unshift(data)
       this.last_messages.pop()
     },
+    recordMessageTick() {
+      this.recentTimes.push(Date.now())
+      this.pruneRecentTimes()
+    },
+    pruneRecentTimes() {
+      // Sliding 5-minute window; pruned every 5s so the badge ticks down
+      // visibly when no new messages arrive.
+      const cutoff = Date.now() - 5 * 60 * 1000
+      if (this.recentTimes.length && this.recentTimes[0] <= cutoff) {
+        this.recentTimes = this.recentTimes.filter(t => t > cutoff)
+      }
+    },
     openWS() {
       const socket = new WebSocket(`${this.api_server.ws_protocol}//${this.api_server.host}/api/ws0/messages?history=${QUEUE_SIZE}`)
       socket._intentionallyClosed = false
@@ -145,6 +181,7 @@ export default {
           return
         }
 
+        this.recordMessageTick()
         if (this.last_messages.length === QUEUE_SIZE)
           return this.pushToMessageQueue(data)
 
@@ -212,6 +249,9 @@ export default {
     }).finally(() => { this.addresses_loading = false })
     this.startDashboardPolling()
     document.addEventListener('visibilitychange', this.onVisibilityChange)
+    // Tick every 5s to keep the "/60s" chip in sync even when no new
+    // messages arrive (so the count decreases visibly as time passes).
+    this.rateTickTimer = setInterval(this.pruneRecentTimes, 5000)
   },
   watch: {
     'api_server.host'() {
@@ -224,12 +264,56 @@ export default {
   beforeDestroy() {
     this.closeWS()
     this.stopDashboardPolling()
+    if (this.rateTickTimer) { clearInterval(this.rateTickTimer); this.rateTickTimer = null }
     document.removeEventListener('visibilitychange', this.onVisibilityChange)
   }
 }
 </script>
 
 <style lang="scss" scoped>
+.ws-status {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.ws-status__dot {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 0 currentColor;
+}
+
+.ws-status--live { color: #1e9c2e; }
+.ws-status--live .ws-status__dot {
+  animation: ws-pulse 1.6s ease-out infinite;
+}
+
+.ws-status--connecting { color: #c69200; }
+.ws-status--connecting .ws-status__dot {
+  animation: ws-pulse 2.4s ease-out infinite;
+  opacity: 0.7;
+}
+
+.ws-status--error { color: #d9245a; }
+.ws-status--error .ws-status__dot {
+  animation: none;
+}
+
+@keyframes ws-pulse {
+  0%   { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+  70%  { box-shadow: 0 0 0 0.4rem rgba(0, 0, 0, 0); opacity: 0.8; }
+  100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); opacity: 1; }
+}
+
+.ws-rate {
+  font-weight: 500;
+  font-size: 0.72rem;
+  vertical-align: middle;
+}
+
 .messages-list-header {
   display: flex;
   align-items: center;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -39,7 +39,7 @@
 
 <script>
 import { mapState } from 'vuex'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import MessageList from '@/components/MessageList.vue'
 import MessageTable from '@/components/MessageTable.vue'
 import AddressLink from '@/components/AddressLink'
@@ -91,10 +91,10 @@ export default {
   },
   methods: {
     dateformat(dt) {
-      return moment.unix(dt).format('lll')
+      return dayjs.unix(dt).format('lll')
     },
     reldateformat(dt) {
-      return moment.unix(dt).fromNow()
+      return dayjs.unix(dt).fromNow()
     },
     confirm_text(message) {
       let chains = [...new Set(message.confirmations.map(c => c.chain))];

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,6 +3,8 @@
     <div class="section-body">
       <DashboardStats />
 
+      <TaglineRotator />
+
       <b-row>
         <b-col cols="12" md="6">
           <b-card no-body>
@@ -52,6 +54,7 @@ import dayjs from 'dayjs'
 import MessageList from '@/components/MessageList.vue'
 import AddressLink from '@/components/AddressLink'
 import DashboardStats from '@/components/DashboardStats.vue'
+import TaglineRotator from '@/components/TaglineRotator.vue'
 
 const QUEUE_SIZE = 15
 
@@ -99,7 +102,8 @@ export default {
   components: {
     MessageList,
     AddressLink,
-    DashboardStats
+    DashboardStats,
+    TaglineRotator
   },
   methods: {
     dateformat(dt) {
@@ -128,7 +132,7 @@ export default {
       this.query_status.has_error = false
 
       socket.addEventListener('message', (e) => {
-        // First message proves the connection is healthy — reset backoff.
+        // First message proves the connection is healthy. Reset backoff.
         this.reconnectDelay = 1000
         let data
         try {
@@ -271,7 +275,7 @@ export default {
   border-bottom: none;
 }
 
-/* Keep the table within its card on all viewports — the b-table-stacked
+/* Keep the table within its card on all viewports; the b-table-stacked
    layout otherwise reports natural content width via min-content. */
 ::v-deep .home-addresses-table,
 ::v-deep .home-addresses-table .table-responsive {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <div class="section-body">
+      <DashboardStats />
+
       <b-row>
         <b-col cols="12" md="6">
           <b-card no-body>
@@ -43,6 +45,7 @@ import dayjs from 'dayjs'
 import MessageList from '@/components/MessageList.vue'
 import MessageTable from '@/components/MessageTable.vue'
 import AddressLink from '@/components/AddressLink'
+import DashboardStats from '@/components/DashboardStats.vue'
 
 const QUEUE_SIZE = 15
 
@@ -54,6 +57,8 @@ export default {
       message_socket: null,
       reconnectTimer: null,
       reconnectDelay: 1000,
+      metricsTimer: null,
+      ratesTimer: null,
       messages_fields: [
         { key: 'item_hash', label: 'Item Hash', class: 'hash' },
         { key: 'type', label: 'Type' },
@@ -87,7 +92,8 @@ export default {
   components: {
     MessageList,
     MessageTable,
-    AddressLink
+    AddressLink,
+    DashboardStats
   },
   methods: {
     dateformat(dt) {
@@ -162,6 +168,27 @@ export default {
         this.message_socket.close()
         this.message_socket = null
       }
+    },
+    startDashboardPolling() {
+      this.$store.dispatch('load_metrics')
+      this.$store.dispatch('load_message_rates')
+      if (!this.metricsTimer) {
+        this.metricsTimer = setInterval(() => this.$store.dispatch('load_metrics'), 10000)
+      }
+      if (!this.ratesTimer) {
+        this.ratesTimer = setInterval(() => this.$store.dispatch('load_message_rates'), 60000)
+      }
+    },
+    stopDashboardPolling() {
+      if (this.metricsTimer) { clearInterval(this.metricsTimer); this.metricsTimer = null }
+      if (this.ratesTimer) { clearInterval(this.ratesTimer); this.ratesTimer = null }
+    },
+    onVisibilityChange() {
+      if (document.hidden) {
+        this.stopDashboardPolling()
+      } else {
+        this.startDashboardPolling()
+      }
     }
   },
   mounted() {
@@ -172,16 +199,21 @@ export default {
       sortBy: 'total',
       sortOrder: -1
     })
+    this.startDashboardPolling()
+    document.addEventListener('visibilitychange', this.onVisibilityChange)
   },
   watch: {
     'api_server.host'() {
       this.closeWS()
       this.reconnectDelay = 1000
       this.openWS()
+      this.startDashboardPolling()
     }
   },
   beforeDestroy() {
     this.closeWS()
+    this.stopDashboardPolling()
+    document.removeEventListener('visibilitychange', this.onVisibilityChange)
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -270,4 +270,12 @@ export default {
 ::v-deep .home-addresses-table tbody tr:last-child td {
   border-bottom: none;
 }
+
+/* Keep the table within its card on all viewports — the b-table-stacked
+   layout otherwise reports natural content width via min-content. */
+::v-deep .home-addresses-table,
+::v-deep .home-addresses-table .table-responsive {
+  width: 100%;
+  max-width: 100%;
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -136,6 +136,12 @@ export default {
   },
   mounted() {
     this.openWS()
+    this.$store.dispatch('load_addresses', {
+      page: 1,
+      perPage: 25,
+      sortBy: 'messages',
+      sortOrder: -1
+    })
   },
   watch: {
     'api_server.host'() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -60,8 +60,8 @@ export default {
       addresses_fields: [
         { key: 'address', label: 'Address' },
         { key: 'messages', label: 'Messages', class: 'text-right' },
-        { key: 'posts', label: 'Posts', class: 'text-right' },
-        { key: 'aggregates', label: 'Aggregates', class: 'text-right' }
+        { key: 'post', label: 'Posts', class: 'text-right' },
+        { key: 'aggregate', label: 'Aggregates', class: 'text-right' }
       ],
       query_status: {
         is_loading: false,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -139,7 +139,7 @@ export default {
     this.$store.dispatch('load_addresses', {
       page: 1,
       perPage: 25,
-      sortBy: 'messages',
+      sortBy: 'total',
       sortOrder: -1
     })
   },

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -222,21 +222,10 @@ export default {
       this.$forceUpdate()
     },
     async getMessages () {
-      let args = {
-        hashes: this.hash
-      }
-
-      console.log(this.hash)
-
-      if (this.address) { args['addresses'] = this.address }
-
-      if (this.type) { args['msgType'] = this.type }
-
-      let response = await axios.get(
-        `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages.json`,
-        { params: args }
+      const response = await axios.get(
+        `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages/${this.hash}`
       )
-      this.messages = response.data.messages
+      this.messages = response.data.message ? [response.data.message] : []
     },
     async getProgramSource () {
       try {

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -8,7 +8,14 @@
       <h1>Message detail</h1>
     </div>
     <div class="section-body">
-      <h2 class="section-title">{{hash}}</h2>
+      <div class="d-flex align-items-center flex-wrap section-title-row">
+        <h2 class="section-title mb-0 mr-3">{{hash}}</h2>
+        <router-link :to="{ name: 'verify', params: { hash } }"
+          class="btn btn-sm btn-outline-primary verify-cta"
+          v-b-tooltip.hover title="Prove this message is signed and anchored on-chain">
+          <i class="fas fa-shield-alt"></i> Verify
+        </router-link>
+      </div>
       <p class="section-lead" v-if="chain&&address&&type">
         Looking for this {{type}} message on {{chain}}, sent by <address-link :address="address" :chain="chain" />
         <span v-if="messages.length"> {{reldateformat(messages[0].time)}}</span>.
@@ -274,5 +281,15 @@ export default {
 .vjs-tree {
   font-size: 10px !important;
   line-height: 1.5em;
+}
+
+.section-title-row {
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.verify-cta {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 </style>

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -189,7 +189,8 @@ export default {
   computed: mapState({
     account: state => state.account,
     api_server: state => state.api_server,
-    profiles: state => state.profiles
+    profiles: state => state.profiles,
+    ipfs_gateway: state => state.ipfs_gateway
   }),
   data () {
     return {
@@ -240,23 +241,25 @@ export default {
     async getProgramSource () {
       try {
         const ref = this.messages[0].content.code.ref
-  
+        const apiBase = `${this.api_server.protocol}//${this.api_server.host}`
+
         if(ref || !this.isProgramSourceLoading || !this.programSource){
           this.isProgramSourceLoading = true
-          
-          const srcQuery = await axios.get(`https://api2.aleph.im/api/v0/messages.json?hashes=${ref}`)
-  
+
+          const srcQuery = await axios.get(`${apiBase}/api/v0/messages.json?hashes=${ref}`)
+
           if(!srcQuery.data.messages[0].content.item_hash){
             throw new Error('No source code found')
           }
 
           const rawSrc = srcQuery.data.messages[0].content.item_hash
 
-          // Shady hack to retrieve the source code from the IPFS gateway instead of the Aleph API
+          // IPFS-style hashes go through the configured IPFS gateway,
+          // anything else is served by the active Aleph node.
           if(rawSrc.startsWith('Q') || rawSrc.startsWith('bafy'))
-            this.programSource = 'https://ipfs.io/ipfs/' + rawSrc
+            this.programSource = this.ipfs_gateway + rawSrc
           else
-            this.programSource = 'https://api2.aleph.im/api/v0/storage/raw/' + rawSrc
+            this.programSource = `${apiBase}/api/v0/storage/raw/${rawSrc}`
         }
 
         this.isProgramSourceLoading = false

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -260,12 +260,12 @@ export default {
     }
   },
   watch: {
-    async hash () {
-      await this.update()
+    hash: {
+      immediate: true,
+      async handler () {
+        await this.update()
+      }
     }
-  },
-  async mounted () {
-    await this.update()
   }
 }
 </script>

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -171,7 +171,7 @@
 <script>
 import { mapState } from 'vuex'
 import axios from 'axios'
-import moment from 'moment'
+import dayjs from 'dayjs'
 import AddressLink from '@/components/AddressLink'
 import VueJsonPretty from 'vue-json-pretty'
 import 'vue-json-pretty/lib/styles.css'
@@ -208,10 +208,10 @@ export default {
   },
   methods: {
     dateformat (dt) {
-      return moment.unix(dt).format('lll')
+      return dayjs.unix(dt).format('lll')
     },
     reldateformat (dt) {
-      return moment.unix(dt).fromNow()
+      return dayjs.unix(dt).fromNow()
     },
     getHash (hash) {
       if (hash.$binary !== undefined) { return base64toHEX(hash.$binary) } else { return hash }

--- a/src/views/MessageDetail.vue
+++ b/src/views/MessageDetail.vue
@@ -29,30 +29,48 @@
             <b-tabs pills card>
               <b-tab title="Message Content" v-if="message.content">
                 <b-card-body>
-                  <vue-json-pretty
-                    :data="message.content" highlightMouseoverNode>
-                  </vue-json-pretty>
+                  <template v-if="isHeavy(message.content) && !isExpanded(message, 'content')">
+                    <div class="json-heavy-gate">
+                      <p class="text-muted mb-2">
+                        Content is {{ formatBytes(sizeOf(message.content)) }}. Rendering is
+                        deferred to keep the page responsive.
+                      </p>
+                      <b-button variant="primary" size="sm"
+                        @click="expand(message, 'content')">
+                        Show content
+                      </b-button>
+                    </div>
+                  </template>
+                  <vue-json-pretty v-else :data="message.content" :deep="1"
+                    highlightMouseoverNode />
                 </b-card-body>
               </b-tab>
               <b-tab title="Signature" v-if="message.signature">
                 <b-card-body>
-                  <vue-json-pretty
-                    :data="{signature: message.signature}" highlightMouseoverNode>
-                  </vue-json-pretty>
+                  <vue-json-pretty :data="{signature: message.signature}" :deep="1"
+                    highlightMouseoverNode />
                 </b-card-body>
               </b-tab>
               <b-tab title="Confirmations" v-if="message.confirmations">
                 <b-card-body>
-                  <vue-json-pretty
-                    :data="message.confirmations" highlightMouseoverNode>
-                  </vue-json-pretty>
+                  <vue-json-pretty :data="message.confirmations" :deep="1"
+                    highlightMouseoverNode />
                 </b-card-body>
               </b-tab>
               <b-tab title="Raw stored">
                 <b-card-body>
-                  <vue-json-pretty
-                    :data="message" highlightMouseoverNode>
-                  </vue-json-pretty>
+                  <template v-if="isHeavy(message) && !isExpanded(message, 'raw')">
+                    <div class="json-heavy-gate">
+                      <p class="text-muted mb-2">
+                        Raw message is {{ formatBytes(sizeOf(message)) }}. Rendering is
+                        deferred to keep the page responsive.
+                      </p>
+                      <b-button variant="primary" size="sm" @click="expand(message, 'raw')">
+                        Show raw
+                      </b-button>
+                    </div>
+                  </template>
+                  <vue-json-pretty v-else :data="message" :deep="1" highlightMouseoverNode />
                 </b-card-body>
               </b-tab>
             </b-tabs>
@@ -188,6 +206,10 @@ function base64toHEX (base64) {
   return buffer.toString('hex')
 }
 
+// Above this serialized size (~100 KB), default to a deferred render so a
+// huge aggregate (e.g. corechannel state) doesn't freeze the tab switch.
+const HEAVY_JSON_THRESHOLD = 100 * 1024
+
 export default {
   name: 'message-detail',
   components: {
@@ -204,7 +226,9 @@ export default {
       messages: [],
       programSource: null,
       isProgramSourceLoading: false,
-      programSourceError: false
+      programSourceError: false,
+      // { '<item_hash>:content' | '<item_hash>:raw' : true }
+      expandedJson: {}
     }
   },
   props: {
@@ -222,6 +246,23 @@ export default {
     },
     getHash (hash) {
       if (hash.$binary !== undefined) { return base64toHEX(hash.$binary) } else { return hash }
+    },
+    sizeOf (value) {
+      try { return JSON.stringify(value).length } catch (e) { return 0 }
+    },
+    isHeavy (value) {
+      return this.sizeOf(value) > HEAVY_JSON_THRESHOLD
+    },
+    isExpanded (message, slot) {
+      return Boolean(this.expandedJson[message.item_hash + ':' + slot])
+    },
+    expand (message, slot) {
+      this.$set(this.expandedJson, message.item_hash + ':' + slot, true)
+    },
+    formatBytes (n) {
+      if (n < 1024) return n + ' B'
+      if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB'
+      return (n / 1024 / 1024).toFixed(2) + ' MB'
     },
     async update () {
       await this.getMessages()
@@ -291,5 +332,13 @@ export default {
 .verify-cta {
   flex: 0 0 auto;
   white-space: nowrap;
+}
+
+.json-heavy-gate {
+  text-align: center;
+  padding: 1.5rem 0.5rem;
+  background: rgba(81, 0, 205, 0.04);
+  border: 1px dashed rgba(81, 0, 205, 0.2);
+  border-radius: 0.5rem;
 }
 </style>

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -155,7 +155,7 @@
 
       <b-table responsive table-class="compact mb-0 messages-table"
         :class="{ 'is-loading-data': query_status.is_loading }"
-        :items="messages" :fields="message_fields" stacked="sm">
+        :items="messages" :fields="message_fields">
         <template v-slot:cell(item_hash)="data">
           <div class="d-flex align-items-center">
             <MessageIcon :messageType="data.item.type" />
@@ -200,8 +200,10 @@
 
       <b-card-footer class="d-flex justify-content-between bg-whitesmoke">
         Total: {{ total_msg }}
-        <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="9" class="mb-0" size="sm"
-          v-if="!hasPageLoaded"></b-pagination>
+        <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="9"
+          class="mb-0 d-none d-md-inline-flex" size="sm" v-if="!hasPageLoaded"></b-pagination>
+        <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="3"
+          class="mb-0 d-md-none" size="sm" v-if="!hasPageLoaded"></b-pagination>
       </b-card-footer>
     </b-card>
   </div>

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -183,12 +183,12 @@
             variant="light">{{ data.item.content.key }}</b-badge>
           <b-badge v-else-if="data.item.type === 'POST' && data.item.content && data.item.content.type"
             variant="light">{{ data.item.content.type }}</b-badge>
-          <span v-else class="text-muted">—</span>
+          <span v-else class="text-muted">-</span>
         </template>
 
         <template v-slot:cell(channel)="data">
           <span v-if="data.value">{{ data.value }}</span>
-          <span v-else class="text-muted">—</span>
+          <span v-else class="text-muted">-</span>
         </template>
 
         <template v-slot:cell(confirmed)="data">

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -1,12 +1,17 @@
 <template>
   <div>
     <template v-if="showAdvancedFilters">
-      <div class="position-absolute mt-n5 rounded ml-4 ml-lg-0 d-flex">
-        <span class="filtertoggle" @click="toggleAdvancedFilters()">Hide advanced filters</span>
-      </div>
-
       <b-card>
         <b-container fluid>
+          <b-row class="mb-2">
+            <b-col sm="12" class="d-flex justify-content-start">
+              <span class="filtertoggle filtertoggle-inline" @click="toggleAdvancedFilters()">
+                <i class="fas fa-chevron-up"></i>
+                Hide advanced filters
+              </span>
+            </b-col>
+          </b-row>
+
           <b-row class="my-1">
             <b-col sm="6">
               <b-form-group id="fg_channel" label="Channel(s)" label-for="_input_channels">
@@ -67,7 +72,7 @@
           </b-row>
 
           <b-row class="my-1">
-            <b-col sm="12" class="d-flex justify-content-end">
+            <b-col sm="12" class="d-flex justify-content-start">
               <span class="filtertoggle filtertoggle-inline" @click="toggleMoreFilters()">
                 <i class="fas" :class="showMoreFilters ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
                 {{ showMoreFilters ? 'Hide more filters' : 'Show more filters' }}
@@ -138,26 +143,25 @@
       </b-card>
     </template>
 
-    <template v-else>
-      <div class="position-absolute mt-n5 rounded ml-4 ml-lg-0 d-flex">
-        <div style="min-width: 200px;">
-          <v-select :options="channels" @input="e => setQP('channels', e?.join(','))" placeholder="Filter channels"
-            :value="filters.channels" multiple />
-        </div>
-        <div class="ml-3 pl-3 border-left border-light d-flex align-items-center">
-          <span class="filtertoggle" @click="toggleAdvancedFilters()">Show advanced filters</span>
-        </div>
-      </div>
-    </template>
-
     <b-card no-body class="card-primary">
-      <b-card-header class="d-flex justify-content-between">
-        <h4>{{ isAggregatesView ? 'Aggregates' : 'Messages' }}
-          <b-spinner small class="ml-3" label="Loading" v-if="query_status.is_loading" />
+      <b-card-header class="d-flex align-items-center flex-wrap messages-header">
+        <h4 class="mb-0 mr-3">
+          {{ isAggregatesView ? 'Aggregates' : 'Messages' }}
+          <b-spinner small class="ml-2" label="Loading" v-if="query_status.is_loading" />
         </h4>
 
-        <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="4" class="mb-0" size="sm"
-          v-if="!hasPageLoaded"></b-pagination>
+        <template v-if="!showAdvancedFilters">
+          <div class="header-channel-filter mr-3">
+            <v-select :options="channels" @input="e => setQP('channels', e?.join(','))" placeholder="Filter channels"
+              :value="filters.channels" multiple />
+          </div>
+          <span class="filtertoggle filtertoggle-header" @click="toggleAdvancedFilters()">
+            Show advanced filters
+          </span>
+        </template>
+
+        <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="4" class="mb-0 ml-auto"
+          size="sm" v-if="!hasPageLoaded"></b-pagination>
       </b-card-header>
 
       <b-table v-if="isAggregatesView" responsive table-class="compact mb-0" :items="aggregates"
@@ -439,6 +443,18 @@ export default {
 .filtertoggle.filtertoggle-inline {
   color: inherit;
   font-size: 0.85em;
+}
+
+.messages-header .filtertoggle-header {
+  color: inherit;
+  font-size: 0.9em;
+  white-space: nowrap;
+}
+
+.messages-header .header-channel-filter {
+  min-width: 220px;
+  max-width: 360px;
+  flex: 1 1 220px;
 }
 
 .aggregate-content {

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -126,7 +126,6 @@ export default {
     return {
       messages: [],
       aggregates: [],
-      channels: [],
       per_page: 15,
       total_msg: 0,
       page: 1,
@@ -159,7 +158,8 @@ export default {
     ...mapState({
       account: state => state.account,
       api_server: state => state.api_server,
-      profiles: state => state.profiles
+      profiles: state => state.profiles,
+      channels: state => state.channels
     })
   },
   props: {
@@ -174,7 +174,7 @@ export default {
   methods: {
     async refresh() {
       await this.loadData()
-      await this.getChannels()
+      await this.$store.dispatch('load_channels')
     },
     contentPreview(value) {
       const json = JSON.stringify(value)
@@ -226,18 +226,6 @@ export default {
 
       this.messages = messages // display all for now
       this.total_msg = response.data.pagination_total
-    },
-    async getChannels() {
-      const response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/channels/list.json`)
-      try {
-        const { channels } = response.data
-
-        // FIXME
-        // A null channel is stopping the select component from rendering
-        this.channels = channels.filter(x => x != null)
-      } catch (error) {
-        this.channels = []
-      }
     },
     toggleAdvancedFilters() {
       return this.$router.push({
@@ -291,7 +279,7 @@ export default {
     }
   },
   async created() {
-    await this.getChannels()
+    await this.$store.dispatch('load_channels')
     await this.loadQP(this.$route.query)
 
     this.$watch('page', page => {

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -83,13 +83,24 @@
 
     <b-card no-body class="card-primary">
       <b-card-header class="d-flex justify-content-between">
-        <h4>Messages <b-spinner small class="ml-3" label="Loading messages" v-if="query_status.is_loading" /></h4>
+        <h4>{{ isAggregatesView ? 'Aggregates' : 'Messages' }}
+          <b-spinner small class="ml-3" label="Loading" v-if="query_status.is_loading" />
+        </h4>
 
         <b-pagination v-model="page" :total-rows="total_msg" :per-page="per_page" limit="4" class="mb-0" size="sm"
           v-if="!hasPageLoaded"></b-pagination>
       </b-card-header>
 
-      <MessageList :messages="messages" class="compact" detailed />
+      <b-table v-if="isAggregatesView" responsive table-class="compact mb-0" :items="aggregates"
+        :fields="aggregate_fields" stacked="sm">
+        <template v-slot:cell(address)="data">
+          <AddressLink :address="data.value" class="address" />
+        </template>
+        <template v-slot:cell(content)="data">
+          <code class="aggregate-content">{{ contentPreview(data.value) }}</code>
+        </template>
+      </b-table>
+      <MessageList v-else :messages="messages" class="compact" detailed />
 
       <b-card-footer class="d-flex justify-content-between bg-whitesmoke">
         Total: {{ total_msg }}
@@ -106,6 +117,7 @@ import axios from 'axios'
 import 'vue-select/dist/vue-select.css'
 
 import MessageList from '@/components/MessageList.vue'
+import AddressLink from '@/components/AddressLink.vue'
 import { toUnixTimestamp } from '../helpers.js'
 
 export default {
@@ -113,6 +125,7 @@ export default {
   data() {
     return {
       messages: [],
+      aggregates: [],
       channels: [],
       per_page: 15,
       total_msg: 0,
@@ -128,29 +141,71 @@ export default {
         startDate: null,
         endDate: null
       },
+      aggregate_fields: [
+        { key: 'address', label: 'Address' },
+        { key: 'key', label: 'Key' },
+        { key: 'content', label: 'Content' }
+      ],
       query_status: {
         is_loading: false,
         has_error: false
       }
     }
   },
-  computed: mapState({
-    account: state => state.account,
-    api_server: state => state.api_server,
-    profiles: state => state.profiles
-  }),
+  computed: {
+    isAggregatesView() {
+      return this.filters.type === 'AGGREGATE'
+    },
+    ...mapState({
+      account: state => state.account,
+      api_server: state => state.api_server,
+      profiles: state => state.profiles
+    })
+  },
   props: {
     msg_type: {
       type: String
     }
   },
   components: {
-    MessageList
+    MessageList,
+    AddressLink
   },
   methods: {
     async refresh() {
-      await this.getMessages()
+      await this.loadData()
       await this.getChannels()
+    },
+    contentPreview(value) {
+      const json = JSON.stringify(value)
+      return json.length > 200 ? json.slice(0, 200) + '…' : json
+    },
+    async loadData() {
+      if (this.isAggregatesView) {
+        await this.getAggregates()
+      } else {
+        await this.getMessages()
+      }
+    },
+    async getAggregates() {
+      this.query_status.is_loading = true
+      try {
+        const response = await axios.get(
+          `${this.api_server.protocol}//${this.api_server.host}/api/v0/aggregates`,
+          {
+            params: {
+              pagination: this.per_page,
+              page: this.page,
+              addresses: this.filters.sender || undefined,
+              keys: this.filters.keys ? this.filters.keys.replace(/\s/g, '') : undefined
+            }
+          }
+        )
+        this.aggregates = response.data.aggregates || []
+        this.total_msg = response.data.pagination_total || 0
+      } finally {
+        this.query_status.is_loading = false
+      }
     },
     async getMessages() {
       this.query_status.is_loading = true
@@ -164,7 +219,6 @@ export default {
           startDate: toUnixTimestamp(this.filters.startDate),
           endDate: toUnixTimestamp(this.filters.endDate),
           refs: this.filters.refs ? this.filters.refs.replace(/\s/g, '') : undefined,
-          contentKeys: this.filters.keys ? this.filters.keys.replace(/\s/g, '') : undefined,
         }
       })
       let messages = response.data.messages
@@ -224,7 +278,7 @@ export default {
         }
       }
 
-      await this.getMessages()
+      await this.loadData()
     }
   },
   watch: {
@@ -282,5 +336,15 @@ export default {
 
 .filtertoggle:hover {
   text-decoration: none;
+}
+
+.aggregate-content {
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.85em;
+  color: #555;
 }
 </style>

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -163,8 +163,8 @@ export default {
           msgType: this.filters.type !== 'ALL' ? this.filters.type : undefined,
           startDate: toUnixTimestamp(this.filters.startDate),
           endDate: toUnixTimestamp(this.filters.endDate),
-          refs: this.filters.refs ? this.filters.refs.replaceAll(/\s/gi) : undefined,
-          contentKeys: this.filters.keys ? this.filters.keys.replaceAll(/\s/gi) : undefined,
+          refs: this.filters.refs ? this.filters.refs.replace(/\s/g, '') : undefined,
+          contentKeys: this.filters.keys ? this.filters.keys.replace(/\s/g, '') : undefined,
         }
       })
       let messages = response.data.messages

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -56,17 +56,10 @@
           </b-row>
 
           <b-row class="my-1">
-            <b-col sm="6">
+            <b-col sm="12">
               <b-form-group id="fg_refs" label="Refs (comma separated values)" label-for="_input_refs">
                 <b-form-input id="_input_refs" size="sm" :value="filters.refs" @update="e => setQP('refs', e)"
                   debounce="750" trim></b-form-input>
-              </b-form-group>
-            </b-col>
-
-            <b-col sm="6">
-              <b-form-group id="fg_keys" label="Aggregate key" label-for="_input_keys">
-                <b-form-input id="_input_keys" size="sm" :value="filters.keys" @update="e => setQP('keys', e)"
-                  debounce="750" trim :disabled="filters.type !== 'AGGREGATE'"></b-form-input>
               </b-form-group>
             </b-col>
           </b-row>
@@ -85,13 +78,13 @@
               <b-col sm="6">
                 <b-form-group id="fg_hashes" label="Item hashes (comma separated)" label-for="_input_hashes">
                   <b-form-input id="_input_hashes" size="sm" :value="filters.hashes" @update="e => setQP('hashes', e)"
-                    debounce="750" trim :disabled="isAggregatesView"></b-form-input>
+                    debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
               <b-col sm="6">
                 <b-form-group id="fg_tags" label="Tags (comma separated)" label-for="_input_tags">
                   <b-form-input id="_input_tags" size="sm" :value="filters.tags" @update="e => setQP('tags', e)"
-                    debounce="750" trim :disabled="isAggregatesView"></b-form-input>
+                    debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
             </b-row>
@@ -101,16 +94,14 @@
                 <b-form-group id="fg_content_types" label="Content types (comma separated)"
                   label-for="_input_content_types">
                   <b-form-input id="_input_content_types" size="sm" :value="filters.contentTypes"
-                    @update="e => setQP('contentTypes', e)" debounce="750" trim
-                    :disabled="isAggregatesView"></b-form-input>
+                    @update="e => setQP('contentTypes', e)" debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
               <b-col sm="6">
                 <b-form-group id="fg_chains" label="Chains (comma separated, e.g. ETH,AVAX,SOL)"
                   label-for="_input_chains">
                   <b-form-input id="_input_chains" size="sm" :value="filters.chains"
-                    @update="e => setQP('chains', e)" debounce="750" trim
-                    :disabled="isAggregatesView"></b-form-input>
+                    @update="e => setQP('chains', e)" debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
             </b-row>
@@ -120,21 +111,19 @@
                 <b-form-group id="fg_statuses" label="Message status" label-for="_input_statuses">
                   <v-select :options="statusOptions" placeholder="Any status"
                     :value="filters.statuses" id="_input_statuses" multiple
-                    @input="e => setQP('statuses', e?.join(','))" :disabled="isAggregatesView" />
+                    @input="e => setQP('statuses', e?.join(','))" />
                 </b-form-group>
               </b-col>
               <b-col sm="3">
                 <b-form-group id="fg_block_from" label="From block" label-for="_input_block_from">
                   <b-form-input id="_input_block_from" type="number" size="sm" :value="filters.startBlock"
-                    @update="e => setQP('startBlock', e)" debounce="750" trim
-                    :disabled="isAggregatesView"></b-form-input>
+                    @update="e => setQP('startBlock', e)" debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
               <b-col sm="3">
                 <b-form-group id="fg_block_to" label="To block" label-for="_input_block_to">
                   <b-form-input id="_input_block_to" type="number" size="sm" :value="filters.endBlock"
-                    @update="e => setQP('endBlock', e)" debounce="750" trim
-                    :disabled="isAggregatesView"></b-form-input>
+                    @update="e => setQP('endBlock', e)" debounce="750" trim></b-form-input>
                 </b-form-group>
               </b-col>
             </b-row>
@@ -146,7 +135,7 @@
     <b-card no-body class="card-primary">
       <b-card-header class="d-flex align-items-center flex-wrap messages-header">
         <h4 class="mb-0 mr-3">
-          {{ isAggregatesView ? 'Aggregates' : 'Messages' }}
+          Messages
           <b-spinner small class="ml-2" label="Loading" v-if="query_status.is_loading" />
         </h4>
 
@@ -164,16 +153,50 @@
           size="sm" v-if="!hasPageLoaded"></b-pagination>
       </b-card-header>
 
-      <b-table v-if="isAggregatesView" responsive table-class="compact mb-0" :items="aggregates"
-        :fields="aggregate_fields" stacked="sm">
-        <template v-slot:cell(address)="data">
-          <AddressLink :address="data.value" class="address" />
+      <b-table responsive table-class="compact mb-0 messages-table"
+        :class="{ 'is-loading-data': query_status.is_loading }"
+        :items="messages" :fields="message_fields" stacked="sm">
+        <template v-slot:cell(item_hash)="data">
+          <div class="d-flex align-items-center">
+            <MessageIcon :messageType="data.item.type" />
+            <div class="ml-2 min-w-0">
+              <div class="hash-line">
+                <MessageLink :hash="data.item.item_hash" :chain="data.item.chain" :address="data.item.sender"
+                  :type="data.item.type" className="break-xs" />
+                <span class="text-muted small">By</span>
+                <AddressLink :address="data.item.sender" :chain="data.item.chain" class="break-xs" />
+                <template v-if="data.item.content && data.item.content.address
+                  && data.item.content.address !== data.item.sender">
+                  <span class="text-muted small">For</span>
+                  <AddressLink :address="data.item.content.address" class="break-xs" />
+                </template>
+              </div>
+              <div class="text-muted small mt-1" v-b-tooltip.hover :title="dateformat(data.item.time)">
+                {{ reldateformat(data.item.time) }}
+              </div>
+            </div>
+          </div>
         </template>
-        <template v-slot:cell(content)="data">
-          <code class="aggregate-content">{{ contentPreview(data.value) }}</code>
+
+        <template v-slot:cell(subtype)="data">
+          <b-badge v-if="data.item.type === 'AGGREGATE' && data.item.content && data.item.content.key"
+            variant="light">{{ data.item.content.key }}</b-badge>
+          <b-badge v-else-if="data.item.type === 'POST' && data.item.content && data.item.content.type"
+            variant="light">{{ data.item.content.type }}</b-badge>
+          <span v-else class="text-muted">—</span>
+        </template>
+
+        <template v-slot:cell(channel)="data">
+          <span v-if="data.value">{{ data.value }}</span>
+          <span v-else class="text-muted">—</span>
+        </template>
+
+        <template v-slot:cell(confirmed)="data">
+          <b-badge v-if="data.item.confirmed" variant="light" v-b-tooltip.hover
+            :title="confirmTitle(data.item)">confirmed</b-badge>
+          <b-badge v-else variant="light">pending</b-badge>
         </template>
       </b-table>
-      <MessageList v-else :messages="messages" class="compact" detailed />
 
       <b-card-footer class="d-flex justify-content-between bg-whitesmoke">
         Total: {{ total_msg }}
@@ -189,7 +212,9 @@ import { mapState } from 'vuex'
 import axios from 'axios'
 import 'vue-select/dist/vue-select.css'
 
-import MessageList from '@/components/MessageList.vue'
+import dayjs from 'dayjs'
+import MessageIcon from '@/components/MessageIcon.vue'
+import MessageLink from '@/components/MessageLink.vue'
 import AddressLink from '@/components/AddressLink.vue'
 import { toUnixTimestamp } from '../helpers.js'
 
@@ -198,7 +223,6 @@ export default {
   data() {
     return {
       messages: [],
-      aggregates: [],
       per_page: 15,
       total_msg: 0,
       page: 1,
@@ -209,7 +233,6 @@ export default {
         channels: null,
         sender: null,
         type: 'ALL',
-        keys: null,
         refs: null,
         startDate: null,
         endDate: null,
@@ -222,10 +245,11 @@ export default {
         endBlock: null
       },
       statusOptions: ['processed', 'pending', 'rejected', 'forgotten', 'removing', 'removed'],
-      aggregate_fields: [
-        { key: 'address', label: 'Address' },
-        { key: 'key', label: 'Key' },
-        { key: 'content', label: 'Content' }
+      message_fields: [
+        { key: 'item_hash', label: '#' },
+        { key: 'subtype', label: 'Sub Type / Key' },
+        { key: 'channel', label: 'Channel' },
+        { key: 'confirmed', label: 'Confirmed', class: 'text-center' }
       ],
       query_status: {
         is_loading: false,
@@ -234,9 +258,6 @@ export default {
     }
   },
   computed: {
-    isAggregatesView() {
-      return this.filters.type === 'AGGREGATE'
-    },
     ...mapState({
       account: state => state.account,
       api_server: state => state.api_server,
@@ -250,44 +271,25 @@ export default {
     }
   },
   components: {
-    MessageList,
+    MessageIcon,
+    MessageLink,
     AddressLink
   },
   methods: {
     async refresh() {
-      await this.loadData()
+      await this.getMessages()
       await this.$store.dispatch('load_channels')
     },
-    contentPreview(value) {
-      const json = JSON.stringify(value)
-      return json.length > 200 ? json.slice(0, 200) + '…' : json
+    dateformat(dt) {
+      return dayjs.unix(dt).format('lll')
     },
-    async loadData() {
-      if (this.isAggregatesView) {
-        await this.getAggregates()
-      } else {
-        await this.getMessages()
-      }
+    reldateformat(dt) {
+      return dayjs.unix(dt).fromNow()
     },
-    async getAggregates() {
-      this.query_status.is_loading = true
-      try {
-        const response = await axios.get(
-          `${this.api_server.protocol}//${this.api_server.host}/api/v0/aggregates`,
-          {
-            params: {
-              pagination: this.per_page,
-              page: this.page,
-              addresses: this.filters.sender || undefined,
-              keys: this.filters.keys ? this.filters.keys.replace(/\s/g, '') : undefined
-            }
-          }
-        )
-        this.aggregates = response.data.aggregates || []
-        this.total_msg = response.data.pagination_total || 0
-      } finally {
-        this.query_status.is_loading = false
-      }
+    confirmTitle(message) {
+      if (!message.confirmations || !message.confirmations.length) return 'Confirmed'
+      const chains = [...new Set(message.confirmations.map(c => c.chain))]
+      return `${message.confirmations.length} confirmations:\n${chains.join(', ')}`
     },
     csvParam(value) {
       return value ? value.replace(/\s/g, '') || undefined : undefined
@@ -364,7 +366,6 @@ export default {
           this.filters.type = qp.type || 'ALL'
           this.filters.startDate = qp.startDate
           this.filters.endDate = qp.endDate
-          this.filters.keys = qp.keys
           this.filters.refs = qp.refs
           this.filters.hashes = qp.hashes || null
           this.filters.tags = qp.tags || null
@@ -380,7 +381,7 @@ export default {
         }
       }
 
-      await this.loadData()
+      await this.getMessages()
     }
   },
   watch: {
@@ -457,13 +458,42 @@ export default {
   flex: 1 1 220px;
 }
 
-.aggregate-content {
-  display: inline-block;
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 0.85em;
-  color: #555;
+/* Header + row styling matched with the Home dashboard tables. */
+.card table.compact.messages-table thead th {
+  padding: 0.55rem 1.25rem !important;
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  color: #000 !important;
+  text-transform: none !important;
+  background: transparent !important;
+  border-bottom: 1px solid #dee2e6 !important;
+}
+
+.card table.compact.messages-table tbody td {
+  height: auto !important;
+  padding: 0.6rem 1.25rem !important;
+  vertical-align: middle;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.card table.compact.messages-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.is-loading-data {
+  opacity: 0.2;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.messages-table .min-w-0 {
+  min-width: 0;
+}
+
+.messages-table .hash-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 </style>

--- a/src/views/Messages.vue
+++ b/src/views/Messages.vue
@@ -65,6 +65,75 @@
               </b-form-group>
             </b-col>
           </b-row>
+
+          <b-row class="my-1">
+            <b-col sm="12" class="d-flex justify-content-end">
+              <span class="filtertoggle filtertoggle-inline" @click="toggleMoreFilters()">
+                <i class="fas" :class="showMoreFilters ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
+                {{ showMoreFilters ? 'Hide more filters' : 'Show more filters' }}
+              </span>
+            </b-col>
+          </b-row>
+
+          <template v-if="showMoreFilters">
+            <b-row class="my-1">
+              <b-col sm="6">
+                <b-form-group id="fg_hashes" label="Item hashes (comma separated)" label-for="_input_hashes">
+                  <b-form-input id="_input_hashes" size="sm" :value="filters.hashes" @update="e => setQP('hashes', e)"
+                    debounce="750" trim :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+              <b-col sm="6">
+                <b-form-group id="fg_tags" label="Tags (comma separated)" label-for="_input_tags">
+                  <b-form-input id="_input_tags" size="sm" :value="filters.tags" @update="e => setQP('tags', e)"
+                    debounce="750" trim :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+            </b-row>
+
+            <b-row class="my-1">
+              <b-col sm="6">
+                <b-form-group id="fg_content_types" label="Content types (comma separated)"
+                  label-for="_input_content_types">
+                  <b-form-input id="_input_content_types" size="sm" :value="filters.contentTypes"
+                    @update="e => setQP('contentTypes', e)" debounce="750" trim
+                    :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+              <b-col sm="6">
+                <b-form-group id="fg_chains" label="Chains (comma separated, e.g. ETH,AVAX,SOL)"
+                  label-for="_input_chains">
+                  <b-form-input id="_input_chains" size="sm" :value="filters.chains"
+                    @update="e => setQP('chains', e)" debounce="750" trim
+                    :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+            </b-row>
+
+            <b-row class="my-1">
+              <b-col sm="6">
+                <b-form-group id="fg_statuses" label="Message status" label-for="_input_statuses">
+                  <v-select :options="statusOptions" placeholder="Any status"
+                    :value="filters.statuses" id="_input_statuses" multiple
+                    @input="e => setQP('statuses', e?.join(','))" :disabled="isAggregatesView" />
+                </b-form-group>
+              </b-col>
+              <b-col sm="3">
+                <b-form-group id="fg_block_from" label="From block" label-for="_input_block_from">
+                  <b-form-input id="_input_block_from" type="number" size="sm" :value="filters.startBlock"
+                    @update="e => setQP('startBlock', e)" debounce="750" trim
+                    :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+              <b-col sm="3">
+                <b-form-group id="fg_block_to" label="To block" label-for="_input_block_to">
+                  <b-form-input id="_input_block_to" type="number" size="sm" :value="filters.endBlock"
+                    @update="e => setQP('endBlock', e)" debounce="750" trim
+                    :disabled="isAggregatesView"></b-form-input>
+                </b-form-group>
+              </b-col>
+            </b-row>
+          </template>
         </b-container>
       </b-card>
     </template>
@@ -131,6 +200,7 @@ export default {
       page: 1,
       hasPageLoaded: true,
       showAdvancedFilters: false,
+      showMoreFilters: false,
       filters: {
         channels: null,
         sender: null,
@@ -138,8 +208,16 @@ export default {
         keys: null,
         refs: null,
         startDate: null,
-        endDate: null
+        endDate: null,
+        hashes: null,
+        tags: null,
+        contentTypes: null,
+        chains: null,
+        statuses: null,
+        startBlock: null,
+        endBlock: null
       },
+      statusOptions: ['processed', 'pending', 'rejected', 'forgotten', 'removing', 'removed'],
       aggregate_fields: [
         { key: 'address', label: 'Address' },
         { key: 'key', label: 'Key' },
@@ -207,6 +285,13 @@ export default {
         this.query_status.is_loading = false
       }
     },
+    csvParam(value) {
+      return value ? value.replace(/\s/g, '') || undefined : undefined
+    },
+    intParam(value) {
+      const n = parseInt(value, 10)
+      return Number.isFinite(n) ? n : undefined
+    },
     async getMessages() {
       this.query_status.is_loading = true
       let response = await axios.get(`${this.api_server.protocol}//${this.api_server.host}/api/v0/messages.json`, {
@@ -218,7 +303,16 @@ export default {
           msgType: this.filters.type !== 'ALL' ? this.filters.type : undefined,
           startDate: toUnixTimestamp(this.filters.startDate),
           endDate: toUnixTimestamp(this.filters.endDate),
-          refs: this.filters.refs ? this.filters.refs.replace(/\s/g, '') : undefined,
+          refs: this.csvParam(this.filters.refs),
+          hashes: this.csvParam(this.filters.hashes),
+          tags: this.csvParam(this.filters.tags),
+          contentTypes: this.csvParam(this.filters.contentTypes),
+          chains: this.csvParam(this.filters.chains),
+          msgStatuses: this.filters.statuses && this.filters.statuses.length
+            ? this.filters.statuses.join(',')
+            : undefined,
+          startBlock: this.intParam(this.filters.startBlock),
+          endBlock: this.intParam(this.filters.endBlock),
         }
       })
       let messages = response.data.messages
@@ -236,6 +330,15 @@ export default {
         }
       })
     },
+    toggleMoreFilters() {
+      return this.$router.push({
+        name: 'messages',
+        query: {
+          ...this.$route.query,
+          showMoreFilters: Number(!this.showMoreFilters) || undefined
+        }
+      })
+    },
     setQP(name, value) {
       return this.$router.push({
         name: 'messages',
@@ -250,6 +353,7 @@ export default {
       if (qp) {
         try {
           this.showAdvancedFilters = Boolean(parseInt(qp.showAdvancedFilters))
+          this.showMoreFilters = Boolean(parseInt(qp.showMoreFilters))
           this.page = parseInt(qp.page) || 1
           this.filters.channels = qp.channels && qp.channels?.split(',')
           this.filters.sender = qp.sender || null
@@ -258,7 +362,13 @@ export default {
           this.filters.endDate = qp.endDate
           this.filters.keys = qp.keys
           this.filters.refs = qp.refs
-
+          this.filters.hashes = qp.hashes || null
+          this.filters.tags = qp.tags || null
+          this.filters.contentTypes = qp.contentTypes || null
+          this.filters.chains = qp.chains || null
+          this.filters.statuses = qp.statuses ? qp.statuses.split(',') : null
+          this.filters.startBlock = qp.startBlock || null
+          this.filters.endBlock = qp.endBlock || null
         }
         catch (err) {
           console.log('Could not load query parameter')
@@ -324,6 +434,11 @@ export default {
 
 .filtertoggle:hover {
   text-decoration: none;
+}
+
+.filtertoggle.filtertoggle-inline {
+  color: inherit;
+  font-size: 0.85em;
 }
 
 .aggregate-content {

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -14,9 +14,9 @@
         <b-card-body>
           <b-input-group>
             <b-form-input v-model="query" placeholder="Aleph item_hash (64 hex chars)"
-              @keyup.enter="run" :disabled="loading" trim />
+              @keyup.enter="submit" :disabled="loading" trim />
             <b-input-group-append>
-              <b-button variant="primary" :disabled="!query || loading" @click="run">
+              <b-button variant="primary" :disabled="!query || loading" @click="submit">
                 <i class="fas" :class="loading ? 'fa-spinner fa-spin' : 'fa-shield-alt'"></i>
                 Verify
               </b-button>
@@ -52,17 +52,44 @@
         </b-card-body>
       </b-card>
 
-      <!-- Steps 2 + 3 (placeholders for upcoming work) -->
-      <b-card v-if="step1 && step1.canChain" no-body class="verify-step verify-step--placeholder mb-3">
+      <!-- Step 2: decode the anchor tx and surface the IPFS CID -->
+      <b-card v-if="step2" no-body class="verify-step mb-3" :class="step2.statusClass">
         <b-card-body>
-          <div class="d-flex align-items-center">
-            <i class="step-icon fas fa-link text-muted"></i>
-            <h3 class="step-title mb-0 ml-2 text-muted">Anchored on Ethereum</h3>
+          <div class="d-flex align-items-center mb-2">
+            <i class="step-icon fas" :class="step2.icon"></i>
+            <h3 class="step-title mb-0 ml-2">{{ step2.title }}</h3>
           </div>
-          <div class="text-muted small mt-1">
-            Decoding the batch transaction and resolving the IPFS payload will be
-            wired up in the next steps of this page.
+          <div v-if="step2.message" class="verify-step__msg">{{ step2.message }}</div>
+          <dl v-if="step2.fields" class="verify-fields">
+            <template v-for="field in step2.fields">
+              <dt :key="field.label + '-l'">{{ field.label }}</dt>
+              <dd :key="field.label + '-v'">
+                <a v-if="field.href" :href="field.href" target="_blank" rel="noopener noreferrer">
+                  <code>{{ field.value }}</code> <i class="fas fa-external-link-alt fa-xs"></i>
+                </a>
+                <code v-else>{{ field.value }}</code>
+              </dd>
+            </template>
+          </dl>
+        </b-card-body>
+      </b-card>
+
+      <!-- Step 3: fetch the IPFS payload and prove the hash is inside -->
+      <b-card v-if="step3" no-body class="verify-step mb-3" :class="step3.statusClass">
+        <b-card-body>
+          <div class="d-flex align-items-center mb-2">
+            <i class="step-icon fas" :class="step3.icon"></i>
+            <h3 class="step-title mb-0 ml-2">{{ step3.title }}</h3>
           </div>
+          <div v-if="step3.message" class="verify-step__msg">{{ step3.message }}</div>
+          <div v-if="step3.snippet" class="verify-snippet">
+            <span class="verify-snippet__label">Excerpt around the match</span>
+            <pre><span>{{ step3.snippet.before }}</span><mark>{{ step3.snippet.match }}</mark><span>{{ step3.snippet.after }}</span></pre>
+          </div>
+          <details v-if="payload" class="verify-payload">
+            <summary>Show full IPFS payload ({{ payloadSize }})</summary>
+            <vue-json-pretty :data="payload" :deep="1" highlightMouseoverNode />
+          </details>
         </b-card-body>
       </b-card>
 
@@ -82,15 +109,65 @@
 <script>
 import axios from 'axios'
 import { mapState } from 'vuex'
+import VueJsonPretty from 'vue-json-pretty'
+import 'vue-json-pretty/lib/styles.css'
+
+const ETH_RPC = 'https://ethereum-rpc.publicnode.com'
+const IPFS_GATEWAY = 'https://ipfs.aleph.cloud/ipfs/'
+const SNIPPET_CONTEXT = 80
+
+// Decode a hex byte string as UTF-8 (handles multi-byte chars correctly).
+function hexToUtf8Bytes(hex, length) {
+  const bytes = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16)
+  }
+  return new TextDecoder('utf-8').decode(bytes)
+}
+
+// Aleph anchor txs call a contract method with a single ABI-encoded
+// string parameter (the JSON payload). Layout (skip leading 0x):
+//   bytes 0..3   : 4-byte function selector
+//   bytes 4..35  : ABI offset to the string data (typically 0x20)
+//   bytes (offset)..(offset+31) : string length (uint256 big-endian)
+//   bytes (offset+32)..        : UTF-8 string bytes, right-padded to 32
+function decodeAnchorString(inputHex) {
+  const hex = inputHex.startsWith('0x') ? inputHex.slice(2) : inputHex
+  if (hex.length < 8 + 64 + 64) {
+    throw new Error('Input too short to contain an ABI-encoded string')
+  }
+  const data = hex.slice(8) // strip selector
+  const offset = parseInt(data.slice(0, 64), 16) // typically 32
+  const lenStart = offset * 2
+  const length = parseInt(data.slice(lenStart, lenStart + 64), 16)
+  if (!Number.isFinite(length) || length <= 0) {
+    throw new Error('Could not read the string length from the ABI envelope')
+  }
+  const stringHex = data.slice(lenStart + 64, lenStart + 64 + length * 2)
+  return hexToUtf8Bytes(stringHex, length)
+}
 
 export default {
   name: 'verify',
+  components: { VueJsonPretty },
+  props: {
+    hash: { type: String, default: null }
+  },
   data() {
     return {
       query: '',
       loading: false,
       result: null,
-      error: null
+      error: null,
+      chainLoading: false,
+      chainError: null,
+      txInput: null,
+      cid: null,
+      payloadLoading: false,
+      payloadError: null,
+      payload: null,
+      payloadSerialized: '',
+      payloadContainsHash: null
     }
   },
   computed: {
@@ -121,6 +198,7 @@ export default {
       ]
 
       if (ethConf) {
+        const txHash = ethConf.hash.startsWith('0x') ? ethConf.hash : '0x' + ethConf.hash
         return {
           title: 'Found in Aleph and anchored on Ethereum',
           icon: 'fa-check-circle',
@@ -130,8 +208,8 @@ export default {
             ...baseFields,
             { label: 'ETH block', value: '#' + ethConf.height,
               href: 'https://etherscan.io/block/' + ethConf.height },
-            { label: 'anchor tx', value: ethConf.hash,
-              href: 'https://etherscan.io/tx/' + ethConf.hash }
+            { label: 'anchor tx', value: txHash,
+              href: 'https://etherscan.io/tx/' + txHash }
           ],
           canChain: true
         }
@@ -156,15 +234,112 @@ export default {
         fields: baseFields,
         canChain: false
       }
+    },
+    step2() {
+      if (this.chainLoading) {
+        return {
+          title: 'Decoding the anchor transaction…',
+          icon: 'fa-spinner fa-spin',
+          statusClass: 'verify-step--pending'
+        }
+      }
+      if (this.chainError) {
+        return {
+          title: 'Could not decode the anchor transaction',
+          icon: 'fa-exclamation-triangle',
+          statusClass: 'verify-step--error',
+          message: this.chainError
+        }
+      }
+      if (!this.cid) return null
+      return {
+        title: 'IPFS payload identified',
+        icon: 'fa-link',
+        statusClass: 'verify-step--ok',
+        fields: [
+          { label: 'IPFS CID', value: this.cid },
+          { label: 'IPFS link', value: IPFS_GATEWAY + this.cid,
+            href: IPFS_GATEWAY + this.cid }
+        ]
+      }
+    },
+    step3() {
+      if (this.payloadLoading) {
+        return {
+          title: 'Fetching the IPFS payload…',
+          icon: 'fa-spinner fa-spin',
+          statusClass: 'verify-step--pending'
+        }
+      }
+      if (this.payloadError) {
+        return {
+          title: 'Could not fetch the IPFS payload',
+          icon: 'fa-exclamation-triangle',
+          statusClass: 'verify-step--error',
+          message: this.payloadError
+        }
+      }
+      if (this.payloadContainsHash === null) return null
+      const target = (this.result && this.result.item_hash) || (this.query || '').trim()
+      if (this.payloadContainsHash) {
+        return {
+          title: 'Verified: hash is present in the on-chain payload',
+          icon: 'fa-check-circle',
+          statusClass: 'verify-step--ok',
+          snippet: this.buildSnippet(target)
+        }
+      }
+      return {
+        title: 'WARNING: hash NOT present in the on-chain payload',
+        icon: 'fa-exclamation-triangle',
+        statusClass: 'verify-step--error',
+        message:
+          'The IPFS payload was fetched but does not contain this item_hash. ' +
+          'That contradicts what the Aleph API reported and should be investigated.'
+      }
+    },
+    payloadSize() {
+      if (!this.payloadSerialized) return ''
+      const bytes = this.payloadSerialized.length
+      if (bytes < 1024) return bytes + ' B'
+      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' kB'
+      return (bytes / 1024 / 1024).toFixed(2) + ' MB'
+    }
+  },
+  watch: {
+    hash: {
+      immediate: true,
+      handler(newHash) {
+        if (newHash) {
+          this.query = newHash
+          this.run()
+        }
+      }
     }
   },
   methods: {
+    submit() {
+      const hash = (this.query || '').trim()
+      if (!hash) return
+      if (this.$route.params.hash !== hash) {
+        // Sync the URL so the verification result is shareable.
+        // The hash-prop watcher above will pick it up and re-run.
+        this.$router.replace({ name: 'verify', params: { hash } })
+      } else {
+        // Same hash already in the URL; re-run explicitly.
+        this.run()
+      }
+    },
     async run() {
       const hash = (this.query || '').trim()
       if (!hash) return
       this.loading = true
       this.result = null
       this.error = null
+      this.chainLoading = false
+      this.chainError = null
+      this.txInput = null
+      this.cid = null
       try {
         const url = `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages/${hash}`
         const { data } = await axios.get(url)
@@ -179,8 +354,92 @@ export default {
         } else {
           this.error = 'Could not reach the Aleph API. ' + (err.message || '')
         }
+        return
       } finally {
         this.loading = false
+      }
+
+      const ethConf = this.result.confirmations
+        && this.result.confirmations.find(c => c.chain === 'ETH')
+      if (ethConf && ethConf.hash) {
+        this.resolveAnchor(ethConf.hash)
+      }
+    },
+    async resolveAnchor(txHash) {
+      this.chainLoading = true
+      this.chainError = null
+      // Aleph confirmations report the tx hash without the 0x prefix;
+      // ethereum-rpc.publicnode.com rejects unprefixed hashes.
+      const normalizedHash = txHash.startsWith('0x') ? txHash : '0x' + txHash
+      try {
+        const { data } = await axios.post(ETH_RPC, {
+          jsonrpc: '2.0',
+          method: 'eth_getTransactionByHash',
+          params: [normalizedHash],
+          id: 1
+        })
+        if (data.error) {
+          this.chainError = 'RPC error: ' + (data.error.message || JSON.stringify(data.error))
+          return
+        }
+        const tx = data.result
+        if (!tx || !tx.input) {
+          this.chainError = 'Transaction not found or has no input data.'
+          return
+        }
+        this.txInput = tx.input
+        let payload
+        try {
+          payload = JSON.parse(decodeAnchorString(tx.input))
+        } catch (e) {
+          this.chainError = 'Anchor tx input is not a valid ABI-encoded JSON payload: '
+            + (e.message || e)
+          return
+        }
+        if (!payload || !payload.content) {
+          this.chainError = 'Anchor payload has no "content" field (expected the IPFS CID).'
+          return
+        }
+        this.cid = payload.content
+      } catch (err) {
+        this.chainError = 'Could not reach the Ethereum RPC. ' + (err.message || '')
+        return
+      } finally {
+        this.chainLoading = false
+      }
+
+      if (this.cid && this.result && this.result.item_hash) {
+        this.resolvePayload(this.cid, this.result.item_hash)
+      }
+    },
+    async resolvePayload(cid, targetHash) {
+      this.payloadLoading = true
+      this.payloadError = null
+      this.payload = null
+      this.payloadSerialized = ''
+      this.payloadContainsHash = null
+      try {
+        const { data } = await axios.get(IPFS_GATEWAY + cid, { responseType: 'json' })
+        this.payload = data
+        this.payloadSerialized = typeof data === 'string' ? data : JSON.stringify(data)
+        this.payloadContainsHash = this.payloadSerialized.includes(targetHash)
+      } catch (err) {
+        this.payloadError = 'Could not fetch the IPFS payload. ' + (err.message || '')
+      } finally {
+        this.payloadLoading = false
+      }
+    },
+    buildSnippet(target) {
+      if (!this.payloadSerialized || !target) return null
+      const idx = this.payloadSerialized.indexOf(target)
+      if (idx === -1) return null
+      const start = Math.max(0, idx - SNIPPET_CONTEXT)
+      const end = Math.min(this.payloadSerialized.length, idx + target.length + SNIPPET_CONTEXT)
+      return {
+        before: (start > 0 ? '…' : '') + this.payloadSerialized.slice(start, idx),
+        match: target,
+        after: this.payloadSerialized.slice(idx + target.length, end) +
+          (end < this.payloadSerialized.length ? '…' : '')
       }
     }
   }
@@ -274,5 +533,56 @@ export default {
   color: #2b1865;
   padding: 0.1em 0.35em;
   border-radius: 0.25em;
+}
+
+.verify-snippet {
+  margin-top: 0.75rem;
+}
+
+.verify-snippet__label {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+  margin-bottom: 0.25rem;
+}
+
+.verify-snippet pre {
+  background: #f7f5fb;
+  border: 1px solid rgba(81, 0, 205, 0.1);
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+  color: #2b1865;
+}
+
+.verify-snippet mark {
+  background: #d4ff00;
+  color: #2b1865;
+  padding: 0 0.15em;
+  font-weight: 700;
+  border-radius: 0.15em;
+}
+
+.verify-payload {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.verify-payload summary {
+  cursor: pointer;
+  color: #5100cd;
+  font-weight: 500;
+  padding: 0.25rem 0;
+  user-select: none;
+}
+
+.verify-payload summary:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -1,0 +1,278 @@
+<template>
+  <div>
+    <div class="section-header">
+      <h1>Verify on-chain anchoring</h1>
+    </div>
+    <div class="section-body">
+      <p class="verify-lead">
+        Paste an Aleph item_hash to prove the message is in the Aleph database,
+        <br />
+        anchored on Ethereum, and physically present in the batch JSON stored on IPFS.
+      </p>
+
+      <b-card no-body class="verify-form-card mb-4">
+        <b-card-body>
+          <b-input-group>
+            <b-form-input v-model="query" placeholder="Aleph item_hash (64 hex chars)"
+              @keyup.enter="run" :disabled="loading" trim />
+            <b-input-group-append>
+              <b-button variant="primary" :disabled="!query || loading" @click="run">
+                <i class="fas" :class="loading ? 'fa-spinner fa-spin' : 'fa-shield-alt'"></i>
+                Verify
+              </b-button>
+            </b-input-group-append>
+          </b-input-group>
+          <p class="text-muted small mt-2 mb-0" v-if="!result && !error">
+            The lookup happens entirely in your browser against the public Aleph API,
+            a public Ethereum RPC, and a public IPFS gateway. No backend in between.
+          </p>
+        </b-card-body>
+      </b-card>
+
+      <!-- Step 1: Aleph lookup -->
+      <b-card v-if="step1" no-body class="verify-step mb-3" :class="step1.statusClass">
+        <b-card-body>
+          <div class="d-flex align-items-center mb-2">
+            <i class="step-icon fas" :class="step1.icon"></i>
+            <h3 class="step-title mb-0 ml-2">{{ step1.title }}</h3>
+          </div>
+          <div v-if="step1.message" class="verify-step__msg">{{ step1.message }}</div>
+          <dl v-if="step1.fields" class="verify-fields">
+            <template v-for="field in step1.fields">
+              <dt :key="field.label + '-l'">{{ field.label }}</dt>
+              <dd :key="field.label + '-v'">
+                <router-link v-if="field.to" :to="field.to">{{ field.value }}</router-link>
+                <a v-else-if="field.href" :href="field.href" target="_blank" rel="noopener noreferrer">
+                  <code>{{ field.value }}</code> <i class="fas fa-external-link-alt fa-xs"></i>
+                </a>
+                <code v-else>{{ field.value }}</code>
+              </dd>
+            </template>
+          </dl>
+        </b-card-body>
+      </b-card>
+
+      <!-- Steps 2 + 3 (placeholders for upcoming work) -->
+      <b-card v-if="step1 && step1.canChain" no-body class="verify-step verify-step--placeholder mb-3">
+        <b-card-body>
+          <div class="d-flex align-items-center">
+            <i class="step-icon fas fa-link text-muted"></i>
+            <h3 class="step-title mb-0 ml-2 text-muted">Anchored on Ethereum</h3>
+          </div>
+          <div class="text-muted small mt-1">
+            Decoding the batch transaction and resolving the IPFS payload will be
+            wired up in the next steps of this page.
+          </div>
+        </b-card-body>
+      </b-card>
+
+      <b-card v-if="error" no-body class="verify-step verify-step--error mb-3">
+        <b-card-body>
+          <div class="d-flex align-items-center">
+            <i class="step-icon fas fa-exclamation-triangle"></i>
+            <h3 class="step-title mb-0 ml-2">Lookup failed</h3>
+          </div>
+          <div class="verify-step__msg">{{ error }}</div>
+        </b-card-body>
+      </b-card>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import { mapState } from 'vuex'
+
+export default {
+  name: 'verify',
+  data() {
+    return {
+      query: '',
+      loading: false,
+      result: null,
+      error: null
+    }
+  },
+  computed: {
+    ...mapState({
+      api_server: state => state.api_server
+    }),
+    step1() {
+      if (this.loading) {
+        return {
+          title: 'Looking up in Aleph…',
+          icon: 'fa-spinner fa-spin',
+          statusClass: 'verify-step--pending',
+          canChain: false
+        }
+      }
+      if (!this.result) return null
+
+      const m = this.result
+      const conf = m.confirmations && m.confirmations[0]
+      const ethConf = m.confirmations && m.confirmations.find(c => c.chain === 'ETH')
+
+      const baseFields = [
+        { label: 'item_hash', value: m.item_hash },
+        { label: 'type', value: m.type },
+        { label: 'sender', value: m.sender,
+          to: { name: 'address-detail', params: { chain: m.chain, address: m.sender } } },
+        { label: 'channel', value: m.channel || '(none)' }
+      ]
+
+      if (ethConf) {
+        return {
+          title: 'Found in Aleph and anchored on Ethereum',
+          icon: 'fa-check-circle',
+          statusClass: 'verify-step--ok',
+          message: null,
+          fields: [
+            ...baseFields,
+            { label: 'ETH block', value: '#' + ethConf.height,
+              href: 'https://etherscan.io/block/' + ethConf.height },
+            { label: 'anchor tx', value: ethConf.hash,
+              href: 'https://etherscan.io/tx/' + ethConf.hash }
+          ],
+          canChain: true
+        }
+      }
+
+      if (conf) {
+        return {
+          title: 'Found in Aleph, anchored on ' + conf.chain,
+          icon: 'fa-info-circle',
+          statusClass: 'verify-step--warn',
+          message: 'No Ethereum confirmation yet. This verifier only walks the ETH anchor for now.',
+          fields: baseFields,
+          canChain: false
+        }
+      }
+
+      return {
+        title: 'Found in Aleph, not yet anchored',
+        icon: 'fa-hourglass-half',
+        statusClass: 'verify-step--warn',
+        message: 'The message exists in the network but has no on-chain confirmation yet. Try again in a few minutes.',
+        fields: baseFields,
+        canChain: false
+      }
+    }
+  },
+  methods: {
+    async run() {
+      const hash = (this.query || '').trim()
+      if (!hash) return
+      this.loading = true
+      this.result = null
+      this.error = null
+      try {
+        const url = `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages/${hash}`
+        const { data } = await axios.get(url)
+        if (!data || !data.message) {
+          this.error = 'No message found with that item_hash.'
+          return
+        }
+        this.result = data.message
+      } catch (err) {
+        if (err.response && err.response.status === 404) {
+          this.error = 'No message found with that item_hash.'
+        } else {
+          this.error = 'Could not reach the Aleph API. ' + (err.message || '')
+        }
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.verify-lead {
+  font-size: 1.15rem;
+  color: #2b1865;
+  margin-bottom: 1.5rem;
+  max-width: 56em;
+}
+
+.verify-form-card {
+  border: 1px solid rgba(81, 0, 205, 0.15);
+}
+
+.verify-step {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-left-width: 4px;
+}
+
+.verify-step--ok {
+  border-left-color: #47ff59;
+}
+
+.verify-step--warn {
+  border-left-color: #fecd17;
+}
+
+.verify-step--error {
+  border-left-color: #d9245a;
+}
+
+.verify-step--pending {
+  border-left-color: #5100cd;
+}
+
+.verify-step--placeholder {
+  border-left-color: rgba(0, 0, 0, 0.15);
+  border-style: dashed;
+}
+
+.step-icon {
+  font-size: 1.4rem;
+  width: 1.6em;
+  text-align: center;
+}
+
+.verify-step--ok .step-icon { color: #1e9c2e; }
+.verify-step--warn .step-icon { color: #c69200; }
+.verify-step--error .step-icon { color: #d9245a; }
+.verify-step--pending .step-icon { color: #5100cd; }
+
+.step-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.verify-step__msg {
+  color: #495057;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.verify-fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+}
+
+.verify-fields dt {
+  color: #6c757d;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+  align-self: center;
+}
+
+.verify-fields dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.verify-fields code {
+  background: rgba(81, 0, 205, 0.06);
+  color: #2b1865;
+  padding: 0.1em 0.35em;
+  border-radius: 0.25em;
+}
+</style>

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -12,16 +12,23 @@
 
       <b-card no-body class="verify-form-card mb-4">
         <b-card-body>
-          <b-input-group>
-            <b-form-input v-model="query" placeholder="Aleph item_hash (64 hex chars)"
-              @keyup.enter="submit" :disabled="loading" trim />
-            <b-input-group-append>
-              <b-button variant="primary" :disabled="!query || loading" @click="submit">
-                <i class="fas" :class="loading ? 'fa-spinner fa-spin' : 'fa-shield-alt'"></i>
-                Verify
-              </b-button>
-            </b-input-group-append>
-          </b-input-group>
+          <div class="d-flex flex-wrap align-items-center verify-form-row">
+            <b-input-group class="verify-form-input">
+              <b-form-input v-model="query" placeholder="Aleph item_hash (64 hex chars)"
+                @keyup.enter="submit" :disabled="loading" trim />
+              <b-input-group-append>
+                <b-button variant="primary" :disabled="!query || loading" @click="submit">
+                  <i class="fas" :class="loading ? 'fa-spinner fa-spin' : 'fa-shield-alt'"></i>
+                  Verify
+                </b-button>
+              </b-input-group-append>
+            </b-input-group>
+            <b-button v-if="result" variant="outline-secondary" @click="copyLink"
+              class="verify-copy-btn" v-b-tooltip.hover :title="copyTooltip">
+              <i class="fas" :class="copied ? 'fa-check' : 'fa-link'"></i>
+              <span class="ml-1">{{ copied ? 'Copied' : 'Copy link' }}</span>
+            </b-button>
+          </div>
           <p class="text-muted small mt-2 mb-0" v-if="!result && !error">
             The lookup happens entirely in your browser against the public Aleph API,
             a public Ethereum RPC, and a public IPFS gateway. No backend in between.
@@ -188,7 +195,14 @@ export default {
       payloadContainsHash: null,
       sigStatus: null,    // 'valid' | 'invalid' | 'missing' | 'error' | null
       sigChain: null,
-      sigError: null
+      sigError: null,
+      copied: false,
+      copyResetTimer: null
+    }
+  },
+  computed: {
+    copyTooltip() {
+      return this.copied ? 'Copied to clipboard' : 'Copy permalink to this verification'
     }
   },
   computed: {
@@ -376,6 +390,9 @@ export default {
       }
     }
   },
+  beforeDestroy() {
+    if (this.copyResetTimer) clearTimeout(this.copyResetTimer)
+  },
   methods: {
     submit() {
       const hash = (this.query || '').trim()
@@ -387,6 +404,18 @@ export default {
       } else {
         // Same hash already in the URL; re-run explicitly.
         this.run()
+      }
+    },
+    async copyLink() {
+      try {
+        await navigator.clipboard.writeText(window.location.href)
+        this.copied = true
+        if (this.copyResetTimer) clearTimeout(this.copyResetTimer)
+        this.copyResetTimer = setTimeout(() => { this.copied = false }, 2000)
+      } catch (e) {
+        // Fallback for browsers without Clipboard API; users can still
+        // copy from the URL bar.
+        this.copied = false
       }
     },
     async run() {
@@ -547,6 +576,19 @@ export default {
 
 .verify-form-card {
   border: 1px solid rgba(81, 0, 205, 0.15);
+}
+
+.verify-form-row {
+  gap: 0.75rem;
+}
+
+.verify-form-input {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.verify-copy-btn {
+  flex: 0 0 auto;
 }
 
 .verify-step {

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -52,6 +52,23 @@
         </b-card-body>
       </b-card>
 
+      <!-- Step 1b: Signature verification (cryptographic, chain-agnostic step) -->
+      <b-card v-if="stepSig" no-body class="verify-step mb-3" :class="stepSig.statusClass">
+        <b-card-body>
+          <div class="d-flex align-items-center mb-2">
+            <i class="step-icon fas" :class="stepSig.icon"></i>
+            <h3 class="step-title mb-0 ml-2">{{ stepSig.title }}</h3>
+          </div>
+          <div v-if="stepSig.message" class="verify-step__msg">{{ stepSig.message }}</div>
+          <dl v-if="stepSig.fields" class="verify-fields">
+            <template v-for="field in stepSig.fields">
+              <dt :key="field.label + '-l'">{{ field.label }}</dt>
+              <dd :key="field.label + '-v'"><code>{{ field.value }}</code></dd>
+            </template>
+          </dl>
+        </b-card-body>
+      </b-card>
+
       <!-- Step 2: decode the anchor tx and surface the IPFS CID -->
       <b-card v-if="step2" no-body class="verify-step mb-3" :class="step2.statusClass">
         <b-card-body>
@@ -111,6 +128,7 @@ import axios from 'axios'
 import { mapState } from 'vuex'
 import VueJsonPretty from 'vue-json-pretty'
 import 'vue-json-pretty/lib/styles.css'
+import { verifyMessageSignature } from '@/lib/signature.js'
 
 const ETH_RPC = 'https://ethereum-rpc.publicnode.com'
 const IPFS_GATEWAY = 'https://ipfs.aleph.cloud/ipfs/'
@@ -167,7 +185,10 @@ export default {
       payloadError: null,
       payload: null,
       payloadSerialized: '',
-      payloadContainsHash: null
+      payloadContainsHash: null,
+      sigStatus: null,    // 'valid' | 'invalid' | 'missing' | 'error' | null
+      sigChain: null,
+      sigError: null
     }
   },
   computed: {
@@ -192,6 +213,7 @@ export default {
       const baseFields = [
         { label: 'item_hash', value: m.item_hash },
         { label: 'type', value: m.type },
+        { label: 'chain', value: m.chain || '(unknown)' },
         { label: 'sender', value: m.sender,
           to: { name: 'address-detail', params: { chain: m.chain, address: m.sender } } },
         { label: 'channel', value: m.channel || '(none)' }
@@ -304,6 +326,43 @@ export default {
       if (bytes < 1024) return bytes + ' B'
       if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' kB'
       return (bytes / 1024 / 1024).toFixed(2) + ' MB'
+    },
+    stepSig() {
+      if (!this.sigStatus) return null
+      switch (this.sigStatus) {
+        case 'valid':
+          return {
+            title: 'Signature verified',
+            icon: 'fa-key',
+            statusClass: 'verify-step--ok',
+            message: 'The cryptographic signature on this message is valid for sender '
+              + (this.result && this.result.sender) + ' on ' + this.sigChain + '.'
+          }
+        case 'invalid':
+          return {
+            title: 'WARNING: signature does not match sender',
+            icon: 'fa-exclamation-triangle',
+            statusClass: 'verify-step--error',
+            message: 'The signature failed verification against sender '
+              + (this.result && this.result.sender)
+              + '. This is a serious red flag.'
+          }
+        case 'missing':
+          return {
+            title: 'Message has no signature',
+            icon: 'fa-exclamation-triangle',
+            statusClass: 'verify-step--warn',
+            message: this.sigError
+          }
+        case 'error':
+          return {
+            title: 'Could not verify signature',
+            icon: 'fa-exclamation-triangle',
+            statusClass: 'verify-step--error',
+            message: this.sigError
+          }
+      }
+      return null
     }
   },
   watch: {
@@ -340,6 +399,14 @@ export default {
       this.chainError = null
       this.txInput = null
       this.cid = null
+      this.payloadLoading = false
+      this.payloadError = null
+      this.payload = null
+      this.payloadSerialized = ''
+      this.payloadContainsHash = null
+      this.sigStatus = null
+      this.sigChain = null
+      this.sigError = null
       try {
         const url = `${this.api_server.protocol}//${this.api_server.host}/api/v0/messages/${hash}`
         const { data } = await axios.get(url)
@@ -359,10 +426,34 @@ export default {
         this.loading = false
       }
 
+      // Cryptographic check: signature ↔ sender. Lazy-loads the
+      // chain-specific verifier from @aleph-sdk via src/lib/signature.js.
+      this.verifySignature(this.result)
+
       const ethConf = this.result.confirmations
         && this.result.confirmations.find(c => c.chain === 'ETH')
       if (ethConf && ethConf.hash) {
         this.resolveAnchor(ethConf.hash)
+      }
+    },
+    async verifySignature(msg) {
+      this.sigStatus = null
+      this.sigChain = null
+      this.sigError = null
+      const result = await verifyMessageSignature(msg)
+      if (!result.supported) {
+        // Unknown / unsupported chain — leave the signature block hidden.
+        return
+      }
+      this.sigChain = result.chain
+      if (result.missing) {
+        this.sigStatus = 'missing'
+        this.sigError = result.error
+      } else if (result.error) {
+        this.sigStatus = 'error'
+        this.sigError = result.error
+      } else {
+        this.sigStatus = result.valid ? 'valid' : 'invalid'
       }
     },
     async resolveAnchor(txHash) {

--- a/src/views/Verify.vue
+++ b/src/views/Verify.vue
@@ -106,6 +106,9 @@
             <h3 class="step-title mb-0 ml-2">{{ step3.title }}</h3>
           </div>
           <div v-if="step3.message" class="verify-step__msg">{{ step3.message }}</div>
+          <div v-if="step3.gateway" class="verify-gateway">
+            served by <code>{{ step3.gateway }}</code>
+          </div>
           <div v-if="step3.snippet" class="verify-snippet">
             <span class="verify-snippet__label">Excerpt around the match</span>
             <pre><span>{{ step3.snippet.before }}</span><mark>{{ step3.snippet.match }}</mark><span>{{ step3.snippet.after }}</span></pre>
@@ -138,7 +141,19 @@ import 'vue-json-pretty/lib/styles.css'
 import { verifyMessageSignature } from '@/lib/signature.js'
 
 const ETH_RPC = 'https://ethereum-rpc.publicnode.com'
+
+// IPFS gateways tried in parallel for the verification fetch (Promise.any).
+// First successful response wins; the display link in step 2 always points
+// at the Aleph-branded gateway for share-ability.
 const IPFS_GATEWAY = 'https://ipfs.aleph.cloud/ipfs/'
+const IPFS_FALLBACK_GATEWAYS = [
+  'https://ipfs.aleph.cloud/ipfs/',
+  'https://ipfs.io/ipfs/',
+  'https://dweb.link/ipfs/',
+  'https://gateway.pinata.cloud/ipfs/'
+]
+const IPFS_TIMEOUT_MS = 15000
+
 const SNIPPET_CONTEXT = 80
 
 // Decode a hex byte string as UTF-8 (handles multi-byte chars correctly).
@@ -193,6 +208,7 @@ export default {
       payload: null,
       payloadSerialized: '',
       payloadContainsHash: null,
+      payloadGateway: null,
       sigStatus: null,    // 'valid' | 'invalid' | 'missing' | 'error' | null
       sigChain: null,
       sigError: null,
@@ -322,7 +338,8 @@ export default {
           title: 'Verified: hash is present in the on-chain payload',
           icon: 'fa-check-circle',
           statusClass: 'verify-step--ok',
-          snippet: this.buildSnippet(target)
+          snippet: this.buildSnippet(target),
+          gateway: this.payloadGateway
         }
       }
       return {
@@ -538,13 +555,28 @@ export default {
       this.payload = null
       this.payloadSerialized = ''
       this.payloadContainsHash = null
+      this.payloadGateway = null
       try {
-        const { data } = await axios.get(IPFS_GATEWAY + cid, { responseType: 'json' })
+        const attempts = IPFS_FALLBACK_GATEWAYS.map(gateway =>
+          axios.get(gateway + cid, {
+            responseType: 'json',
+            timeout: IPFS_TIMEOUT_MS
+          }).then(response => ({ data: response.data, gateway }))
+        )
+        // Promise.any resolves with the first fulfilled attempt and
+        // throws AggregateError when every gateway fails.
+        const { data, gateway } = await Promise.any(attempts)
         this.payload = data
+        this.payloadGateway = gateway
         this.payloadSerialized = typeof data === 'string' ? data : JSON.stringify(data)
         this.payloadContainsHash = this.payloadSerialized.includes(targetHash)
       } catch (err) {
-        this.payloadError = 'Could not fetch the IPFS payload. ' + (err.message || '')
+        if (err && err.name === 'AggregateError') {
+          this.payloadError = 'All IPFS gateways failed: '
+            + IPFS_FALLBACK_GATEWAYS.length + ' tried, none responded in time.'
+        } else {
+          this.payloadError = 'Could not fetch the IPFS payload. ' + (err.message || '')
+        }
       } finally {
         this.payloadLoading = false
       }
@@ -666,6 +698,19 @@ export default {
   color: #2b1865;
   padding: 0.1em 0.35em;
   border-radius: 0.25em;
+}
+
+.verify-gateway {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #6c757d;
+}
+
+.verify-gateway code {
+  background: rgba(81, 0, 205, 0.06);
+  color: #2b1865;
+  padding: 0.05em 0.3em;
+  border-radius: 0.2em;
 }
 
 .verify-snippet {

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,20 @@ export default defineConfig({
   plugins: [
     vuePlugin({ jsx: true }),
   ],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Silence deprecation warnings emitted by stisla-theme's own SCSS
+        // (third-party, can't be fixed from here).
+        quietDeps: true,
+        // stisla-theme still uses @import internally and propagates that
+        // syntax across our entry SCSS. The migration to @use changes
+        // variable scoping and breaks stisla-theme's global expectations,
+        // so silence the @import deprecation until stisla-theme migrates.
+        silenceDeprecations: ['import']
+      }
+    }
+  },
   define: {
     GIT_DESCRIBE_TAGS: JSON.stringify(getGitDescription())
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vite';
 import path from 'path';
 import vuePlugin from '@vitejs/plugin-vue2';
-import envCompatible from 'vite-plugin-env-compatible';
-import { createHtmlPlugin } from 'vite-plugin-html';
-import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import { execSync } from 'child_process';
 
 const getGitDescription = () => {
@@ -39,15 +36,6 @@ export default defineConfig({
   },
   plugins: [
     vuePlugin({ jsx: true }),
-    viteCommonjs(),
-    envCompatible(),
-    createHtmlPlugin({
-      inject: {
-        data: {
-          title: 'aleph-explorer'
-        }
-      }
-    }),
   ],
   define: {
     GIT_DESCRIBE_TAGS: JSON.stringify(getGitDescription())

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,6 +639,11 @@ csstype@^3.1.0:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+dayjs@^1.11.20:
+  version "1.11.20"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
+  integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
+
 debug@4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
@@ -1187,11 +1192,6 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
-
-moment@^2.29.4:
-  version "2.30.1"
-  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,161 +2,161 @@
 # yarn lockfile v1
 
 
-"@babel/helper-string-parser@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
-  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
-
-"@babel/helper-validator-identifier@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
-  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+"@aashutoshrathi/word-wrap@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
+  integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@babel/parser@^7.23.5":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
-  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
-  dependencies:
-    "@babel/types" "^7.28.4"
+  version "7.23.6"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz"
+  integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
 
-"@babel/types@^7.28.4":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
-  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
-  dependencies:
-    "@babel/helper-string-parser" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
+"@esbuild/aix-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz#7a289c158e29cbf59ea0afc83cc80f06d1c89402"
+  integrity sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==
 
-"@esbuild/android-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
-  integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+"@esbuild/android-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz#b8828d9edfa3a92660644eb8de6e4f3c203d7b17"
+  integrity sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==
 
-"@esbuild/android-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
-  integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
+"@esbuild/android-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz#5ec1847605e05b5dbe5df90db9ff7e3e4c58dca7"
+  integrity sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==
 
-"@esbuild/android-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
-  integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+"@esbuild/android-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz#390642175b88ef82bad4cce03f8ab13fe9b1912e"
+  integrity sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==
 
-"@esbuild/darwin-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
-  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
 
-"@esbuild/darwin-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
-  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+"@esbuild/darwin-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz#c079247d589b6b99449659d94f06951b84bff2e4"
+  integrity sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==
 
-"@esbuild/freebsd-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
-  integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
+"@esbuild/freebsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz#45c456215a486593c94900297202dc11c880a37a"
+  integrity sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==
 
-"@esbuild/freebsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
-  integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+"@esbuild/freebsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz#0399494c1c85e4388e9b7040bd60d48f2a5b0d2c"
+  integrity sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==
 
-"@esbuild/linux-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
-  integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
+"@esbuild/linux-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz#d6d9f09ef0de54116bf459a4d53cac7e0952fe39"
+  integrity sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==
 
-"@esbuild/linux-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
-  integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+"@esbuild/linux-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz#7b42ffa84c288ae94fdc431c1b28a89e3c3b9278"
+  integrity sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==
 
-"@esbuild/linux-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
-  integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
+"@esbuild/linux-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz#deb15d112ed8dd605346b6b953d23a21ff81253f"
+  integrity sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==
 
-"@esbuild/linux-loong64@0.14.54":
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
-  integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
+"@esbuild/linux-loong64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz#81fb89d07eecc79b157dea61033757726fce0ca4"
+  integrity sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==
 
-"@esbuild/linux-loong64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
-  integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+"@esbuild/linux-mips64el@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz#d0e42691b3ff7af9fb2217b70fc01f343bdb62bb"
+  integrity sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==
 
-"@esbuild/linux-mips64el@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
-  integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
+"@esbuild/linux-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz#389f3e5e98f17d477c467cc87136e1a076eead87"
+  integrity sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==
 
-"@esbuild/linux-ppc64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
-  integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+"@esbuild/linux-riscv64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz#763bd60d59b242be12da1e67d5729f3024c605fa"
+  integrity sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==
 
-"@esbuild/linux-riscv64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
-  integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
+"@esbuild/linux-s390x@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz#aac6061634872e4677de693bce8030d73b1fd055"
+  integrity sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==
 
-"@esbuild/linux-s390x@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
-  integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+"@esbuild/linux-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz"
+  integrity sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==
 
-"@esbuild/linux-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
-  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
+"@esbuild/netbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz#814df0ae57a0c386814491b8397eeba82094a947"
+  integrity sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==
 
-"@esbuild/netbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
-  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+"@esbuild/netbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz#e01bdf7e60fa1a08e46d46d960b0d9bb8ac210af"
+  integrity sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==
 
-"@esbuild/openbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
-  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
+"@esbuild/openbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz#4a15c36aacca68d2d5a4c90b710c06759f4c1ffa"
+  integrity sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==
 
-"@esbuild/sunos-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
-  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+"@esbuild/openbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz#475e6101498a8ecce3008d7c388111d7a27c17bd"
+  integrity sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==
 
-"@esbuild/win32-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
-  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
+"@esbuild/openharmony-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz#cfdc3957f0b7a69f1bde129aad17fcc2f6fa033e"
+  integrity sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==
 
-"@esbuild/win32-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
-  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
+"@esbuild/sunos-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz#a013c856fecacd1c3aec985c8afe1d1cb017497d"
+  integrity sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==
 
-"@esbuild/win32-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+"@esbuild/win32-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz#eae05e0f35271cad3898b43168d3e9a3bbaf47e5"
+  integrity sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==
+
+"@esbuild/win32-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz#06161ebc5bf75c08d69feb3c6b22560515913998"
+  integrity sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==
+
+"@esbuild/win32-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
+  integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
-  integrity sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
-    eslint-visitor-keys "^3.4.3"
+    eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.6.1":
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
-  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
+  version "4.10.0"
+  resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz"
+  integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
 "@eslint/eslintrc@^2.1.4":
   version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz#388a269f0f25c1b6adc317b5a2c55714894c70ad"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz"
   integrity sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==
   dependencies:
     ajv "^6.12.4"
@@ -169,80 +169,46 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.57.1":
-  version "8.57.1"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
-  integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
+"@eslint/js@8.56.0":
+  version "8.56.0"
+  resolved "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz"
+  integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@humanwhocodes/config-array@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
-  integrity sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==
+"@humanwhocodes/config-array@^0.11.13":
+  version "0.11.13"
+  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz"
+  integrity sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==
   dependencies:
-    "@humanwhocodes/object-schema" "^2.0.3"
-    debug "^4.3.1"
+    "@humanwhocodes/object-schema" "^2.0.1"
+    debug "^4.1.1"
     minimatch "^3.0.5"
 
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  resolved "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
-"@humanwhocodes/object-schema@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
-  integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
-
-"@jridgewell/gen-mapping@^0.3.5":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
-  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.5.0"
-    "@jridgewell/trace-mapping" "^0.3.24"
-
-"@jridgewell/resolve-uri@^3.1.0":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
-  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
-
-"@jridgewell/source-map@^0.3.3":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.11.tgz#b21835cbd36db656b857c2ad02ebd413cc13a9ba"
-  integrity sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==
-  dependencies:
-    "@jridgewell/gen-mapping" "^0.3.5"
-    "@jridgewell/trace-mapping" "^0.3.25"
-
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
-  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
-
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
-  version "0.3.31"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
+"@humanwhocodes/object-schema@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz"
+  integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+"@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
@@ -250,130 +216,245 @@
 
 "@nuxt/opencollective@^0.3.2":
   version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@nuxt/opencollective/-/opencollective-0.3.3.tgz#80ff0eb8f6fca1d0ed5a089b9688f41bff2dd8ab"
+  resolved "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.3.tgz"
   integrity sha512-6IKCd+gP0HliixqZT/p8nW3tucD6Sv/u/eR2A9X4rxT/6hXlMzA4GZQzq4d2qnBAwSwGpmKyzkyTjNjrhaA25A==
   dependencies:
     chalk "^4.1.0"
     consola "^2.15.0"
     node-fetch "^2.6.7"
 
-"@originjs/vite-plugin-commonjs@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@originjs/vite-plugin-commonjs/-/vite-plugin-commonjs-1.0.3.tgz#2e3fb11ec78847da9422b79c103953f94d667f09"
-  integrity sha512-KuEXeGPptM2lyxdIEJ4R11+5ztipHoE7hy8ClZt3PYaOVQ/pyngd2alaSrPnwyFeOW1UagRBaQ752aA1dTMdOQ==
-  dependencies:
-    esbuild "^0.14.14"
+"@parcel/watcher-android-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz#5f32e0dba356f4ac9a11068d2a5c134ca3ba6564"
+  integrity sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==
 
-"@parcel/watcher-android-arm64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
-  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+"@parcel/watcher-darwin-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz#88d3e720b59b1eceffce98dac46d7c40e8be5e8e"
+  integrity sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==
 
-"@parcel/watcher-darwin-arm64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz#3d26dce38de6590ef79c47ec2c55793c06ad4f67"
-  integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+"@parcel/watcher-darwin-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz#bf05d76a78bc15974f15ec3671848698b0838063"
+  integrity sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==
 
-"@parcel/watcher-darwin-x64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
-  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+"@parcel/watcher-freebsd-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz#8bc26e9848e7303ac82922a5ae1b1ef1bdb48a53"
+  integrity sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==
 
-"@parcel/watcher-freebsd-x64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
-  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+"@parcel/watcher-linux-arm-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz#1328fee1deb0c2d7865079ef53a2ba4cc2f8b40a"
+  integrity sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==
 
-"@parcel/watcher-linux-arm-glibc@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
-  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+"@parcel/watcher-linux-arm-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz#bad0f45cb3e2157746db8b9d22db6a125711f152"
+  integrity sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==
 
-"@parcel/watcher-linux-arm-musl@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
-  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+"@parcel/watcher-linux-arm64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz#b75913fbd501d9523c5f35d420957bf7d0204809"
+  integrity sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==
 
-"@parcel/watcher-linux-arm64-glibc@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
-  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+"@parcel/watcher-linux-arm64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz#da5621a6a576070c8c0de60dea8b46dc9c3827d4"
+  integrity sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==
 
-"@parcel/watcher-linux-arm64-musl@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
-  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+"@parcel/watcher-linux-x64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz"
+  integrity sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==
 
-"@parcel/watcher-linux-x64-glibc@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz#4d2ea0f633eb1917d83d483392ce6181b6a92e4e"
-  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+"@parcel/watcher-linux-x64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz#02400c54b4a67efcc7e2327b249711920ac969e2"
+  integrity sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==
 
-"@parcel/watcher-linux-x64-musl@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz#277b346b05db54f55657301dd77bdf99d63606ee"
-  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+"@parcel/watcher-win32-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz#caae3d3c7583ca0a7171e6bd142c34d20ea1691e"
+  integrity sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==
 
-"@parcel/watcher-win32-arm64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
-  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+"@parcel/watcher-win32-ia32@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz#9ac922550896dfe47bfc5ae3be4f1bcaf8155d6d"
+  integrity sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==
 
-"@parcel/watcher-win32-ia32@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
-  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
-
-"@parcel/watcher-win32-x64@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
-  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
+"@parcel/watcher-win32-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz#73fdafba2e21c448f0e456bbe13178d8fe11739d"
+  integrity sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==
 
 "@parcel/watcher@^2.4.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.5.1.tgz#342507a9cfaaf172479a882309def1e991fb1200"
-  integrity sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==
+  version "2.5.6"
+  resolved "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz"
+  integrity sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==
   dependencies:
-    detect-libc "^1.0.3"
+    detect-libc "^2.0.3"
     is-glob "^4.0.3"
-    micromatch "^4.0.5"
     node-addon-api "^7.0.0"
+    picomatch "^4.0.3"
   optionalDependencies:
-    "@parcel/watcher-android-arm64" "2.5.1"
-    "@parcel/watcher-darwin-arm64" "2.5.1"
-    "@parcel/watcher-darwin-x64" "2.5.1"
-    "@parcel/watcher-freebsd-x64" "2.5.1"
-    "@parcel/watcher-linux-arm-glibc" "2.5.1"
-    "@parcel/watcher-linux-arm-musl" "2.5.1"
-    "@parcel/watcher-linux-arm64-glibc" "2.5.1"
-    "@parcel/watcher-linux-arm64-musl" "2.5.1"
-    "@parcel/watcher-linux-x64-glibc" "2.5.1"
-    "@parcel/watcher-linux-x64-musl" "2.5.1"
-    "@parcel/watcher-win32-arm64" "2.5.1"
-    "@parcel/watcher-win32-ia32" "2.5.1"
-    "@parcel/watcher-win32-x64" "2.5.1"
+    "@parcel/watcher-android-arm64" "2.5.6"
+    "@parcel/watcher-darwin-arm64" "2.5.6"
+    "@parcel/watcher-darwin-x64" "2.5.6"
+    "@parcel/watcher-freebsd-x64" "2.5.6"
+    "@parcel/watcher-linux-arm-glibc" "2.5.6"
+    "@parcel/watcher-linux-arm-musl" "2.5.6"
+    "@parcel/watcher-linux-arm64-glibc" "2.5.6"
+    "@parcel/watcher-linux-arm64-musl" "2.5.6"
+    "@parcel/watcher-linux-x64-glibc" "2.5.6"
+    "@parcel/watcher-linux-x64-musl" "2.5.6"
+    "@parcel/watcher-win32-arm64" "2.5.6"
+    "@parcel/watcher-win32-ia32" "2.5.6"
+    "@parcel/watcher-win32-x64" "2.5.6"
 
-"@rollup/pluginutils@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
+"@rollup/rollup-android-arm-eabi@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz#3a04f01e9f01392bbef5920b94aa3b88794be7ab"
+  integrity sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==
+
+"@rollup/rollup-android-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz#e371b653ceabc900790ae73f5548a0fd7cd63a70"
+  integrity sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==
+
+"@rollup/rollup-darwin-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz#2a5aa70432e39816d666d79287a7324cfc3b4e72"
+  integrity sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==
+
+"@rollup/rollup-darwin-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz#c3b5b49629379cd9cdc5d841bf00ed44ebf393dd"
+  integrity sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==
+
+"@rollup/rollup-freebsd-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz#f929d8e0462fae6602fc960beeabd7287d859283"
+  integrity sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==
+
+"@rollup/rollup-freebsd-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz#c01cb58031226f95d0900b1ec847f4fb32c6e809"
+  integrity sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz#f29d890c4858c8e0d3be01677eef4f6a359eed9d"
+  integrity sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==
+
+"@rollup/rollup-linux-arm-musleabihf@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz#1ebfc8eb9f66136ed2faae5f44995add5ca3c964"
+  integrity sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==
+
+"@rollup/rollup-linux-arm64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz#c1fa823c2c4ce46ba7f61de1a4c3fdadd4fb4e7b"
+  integrity sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==
+
+"@rollup/rollup-linux-arm64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz#a7f18854d0471b78bda8ea38f0891a4e059b571d"
+  integrity sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==
+
+"@rollup/rollup-linux-loong64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz#83658a9a4576bcce8cef85b2c78b9b649d2200c4"
+  integrity sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==
+
+"@rollup/rollup-linux-loong64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz#fd2af677ae3417bb58d57ae37dd0d84686e40244"
+  integrity sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==
+
+"@rollup/rollup-linux-ppc64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz#6481647181c4cf8f1ddbd99f62c84cfc56c1a94a"
+  integrity sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==
+
+"@rollup/rollup-linux-ppc64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz#18610a1a1550e28a5042ca916f898419540f17f4"
+  integrity sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==
+
+"@rollup/rollup-linux-riscv64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz#597bb80465a2621dbe0de0a41c66394a8a7e9a6e"
+  integrity sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==
+
+"@rollup/rollup-linux-riscv64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz#a2a919a9f927ef7f24a60af77e3cb55f1ad59e4d"
+  integrity sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==
+
+"@rollup/rollup-linux-s390x-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz#3166f6ceae7df9bbfddf9f36be1937231e13e3c6"
+  integrity sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==
+
+"@rollup/rollup-linux-x64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz"
+  integrity sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==
+
+"@rollup/rollup-linux-x64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz#97941c6b94d67fe25cde0f027c10a19f2d1fdd39"
+  integrity sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==
+
+"@rollup/rollup-openbsd-x64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz#7aeb7d92e2cd1d399f56daf75c39040b777b6c77"
+  integrity sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==
+
+"@rollup/rollup-openharmony-arm64@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz#925de61ae83bf99aa636e8acea87432e8c0ffaab"
+  integrity sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==
+
+"@rollup/rollup-win32-arm64-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz#888ab83842721491044c46a7407e1f38f3235bb4"
+  integrity sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==
+
+"@rollup/rollup-win32-ia32-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz#fa30ac24e3f0232139d2a47500560a28695764d4"
+  integrity sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==
+
+"@rollup/rollup-win32-x64-gnu@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz#223e2bc93f86e0707568e1fadb5b537e50c976c7"
+  integrity sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==
+
+"@rollup/rollup-win32-x64-msvc@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz#da4f1676d87e2bdf744291b504b0ab79550c3e61"
+  integrity sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==
+
+"@types/estree@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@ungap/structured-clone@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
-  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
+  integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
 "@vitejs/plugin-vue2@^2.3.4":
   version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue2/-/plugin-vue2-2.3.4.tgz#6240f34fa400c32437b458611e176e0b435cf56e"
+  resolved "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.3.4.tgz"
   integrity sha512-LgqtRRedJb1KdmgcllwGX0gtlPvOvtR6pITXmqxGwQhBZaAysg0Hd7wvj3sjCsj4+PENWsqS7O+ceYSOgJ+H9g==
 
 "@vue/compiler-sfc@2.7.16":
   version "2.7.16"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz#ff81711a0fac9c68683d8bb00b63f857de77dc83"
+  resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz"
   integrity sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==
   dependencies:
     "@babel/parser" "^7.23.5"
@@ -384,18 +465,25 @@
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.15.0, acorn@^8.9.0:
-  version "8.15.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
-  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+acorn@^8.9.0:
+  version "8.11.3"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  version "6.15.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -404,53 +492,49 @@ ajv@^6.12.4:
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-async@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
-  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 axios@^1.12.0:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
-  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+  version "1.16.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz"
+  integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 bootstrap-vue@^2.23.1:
   version "2.23.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-vue/-/bootstrap-vue-2.23.1.tgz#8f866f7cda27eb0e7e13a0bea8d55d8fc7a82199"
+  resolved "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.1.tgz"
   integrity sha512-SEWkG4LzmMuWjQdSYmAQk1G/oOKm37dtNfjB5kxq0YafnL2W6qUAmeDTcIZVbPiQd2OQlIkWOMPBRGySk/zGsg==
   dependencies:
     "@nuxt/opencollective" "^0.3.2"
@@ -461,39 +545,27 @@ bootstrap-vue@^2.23.1:
 
 bootstrap@^4.6.1:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
+  resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz"
   integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.14"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz"
+  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
-
-braces@>=3.0.3, braces@^3.0.3:
+braces@>=3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
 
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
@@ -501,241 +573,135 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
 
 callsites@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camel-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
-  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
-  dependencies:
-    pascal-case "^3.1.2"
-    tslib "^2.0.3"
 
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
-  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+chokidar@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz"
+  integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
-    readdirp "^4.0.1"
-
-clean-css@^5.2.2:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
-  integrity sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==
-  dependencies:
-    source-map "~0.6.0"
+    readdirp "^5.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-colorette@^2.0.16:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
 combined-stream@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-connect-history-api-fallback@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
-  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
-
-consola@^2.15.0, consola@^2.15.3:
+consola@^2.15.0:
   version "2.15.3"
-  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
+  resolved "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
 
 cross-spawn@^7.0.2:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
-  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.0.1"
-    domhandler "^4.3.1"
-    domutils "^2.8.0"
-    nth-check "^2.0.1"
-
-css-what@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
-  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
-
 cssesc@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 csstype@^3.1.0:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+debug@4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
-    ms "^2.1.3"
+    ms "2.1.2"
 
 deep-is@^0.1.3:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 doctrine@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
-
-domelementtype@^2.0.1, domelementtype@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
-
-domhandler@^4.2.0, domhandler@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
-  dependencies:
-    domelementtype "^2.2.0"
-
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
-
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
-dotenv-expand@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-8.0.3.tgz#29016757455bcc748469c83a19b36aaf2b83dd6e"
-  integrity sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==
-
-dotenv@^16.0.0:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
-  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
-
 dunder-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
   integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
   dependencies:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-ejs@>=3.1.10, ejs@^3.1.6:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
-  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
-  dependencies:
-    jake "^10.8.5"
-
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+ejs@>=3.1.10:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-5.0.2.tgz#cb8a7922ec1e71193b2507942250e230e200de79"
+  integrity sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==
 
 es-define-property@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  resolved "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
 
 es-errors@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
 es-set-tostringtag@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  resolved "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz"
   integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
   dependencies:
     es-errors "^1.3.0"
@@ -743,188 +709,64 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-esbuild-android-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz#505f41832884313bbaffb27704b8bcaa2d8616be"
-  integrity sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==
-
-esbuild-android-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz#8ce69d7caba49646e009968fe5754a21a9871771"
-  integrity sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==
-
-esbuild-darwin-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz#24ba67b9a8cb890a3c08d9018f887cc221cdda25"
-  integrity sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==
-
-esbuild-darwin-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
-  integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
-
-esbuild-freebsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz#09250f997a56ed4650f3e1979c905ffc40bbe94d"
-  integrity sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==
-
-esbuild-freebsd-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz#bafb46ed04fc5f97cbdb016d86947a79579f8e48"
-  integrity sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==
-
-esbuild-linux-32@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz#e2a8c4a8efdc355405325033fcebeb941f781fe5"
-  integrity sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==
-
-esbuild-linux-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
-  integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
-
-esbuild-linux-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz#dae4cd42ae9787468b6a5c158da4c84e83b0ce8b"
-  integrity sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==
-
-esbuild-linux-arm@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz#a2c1dff6d0f21dbe8fc6998a122675533ddfcd59"
-  integrity sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==
-
-esbuild-linux-mips64le@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz#d9918e9e4cb972f8d6dae8e8655bf9ee131eda34"
-  integrity sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==
-
-esbuild-linux-ppc64le@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz#3f9a0f6d41073fb1a640680845c7de52995f137e"
-  integrity sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==
-
-esbuild-linux-riscv64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz#618853c028178a61837bc799d2013d4695e451c8"
-  integrity sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==
-
-esbuild-linux-s390x@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz#d1885c4c5a76bbb5a0fe182e2c8c60eb9e29f2a6"
-  integrity sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==
-
-esbuild-netbsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz#69ae917a2ff241b7df1dbf22baf04bd330349e81"
-  integrity sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==
-
-esbuild-openbsd-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
-  integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
-
-esbuild-sunos-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
-  integrity sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==
-
-esbuild-windows-32@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz#f8aaf9a5667630b40f0fb3aa37bf01bbd340ce31"
-  integrity sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==
-
-esbuild-windows-64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz#bf54b51bd3e9b0f1886ffdb224a4176031ea0af4"
-  integrity sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==
-
-esbuild-windows-arm64@0.14.54:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz#937d15675a15e4b0e4fafdbaa3a01a776a2be982"
-  integrity sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==
-
-esbuild@^0.14.14:
-  version "0.14.54"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz#8b44dcf2b0f1a66fc22459943dccf477535e9aa2"
-  integrity sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==
+esbuild@>=0.25.0, esbuild@^0.27.0:
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
   optionalDependencies:
-    "@esbuild/linux-loong64" "0.14.54"
-    esbuild-android-64 "0.14.54"
-    esbuild-android-arm64 "0.14.54"
-    esbuild-darwin-64 "0.14.54"
-    esbuild-darwin-arm64 "0.14.54"
-    esbuild-freebsd-64 "0.14.54"
-    esbuild-freebsd-arm64 "0.14.54"
-    esbuild-linux-32 "0.14.54"
-    esbuild-linux-64 "0.14.54"
-    esbuild-linux-arm "0.14.54"
-    esbuild-linux-arm64 "0.14.54"
-    esbuild-linux-mips64le "0.14.54"
-    esbuild-linux-ppc64le "0.14.54"
-    esbuild-linux-riscv64 "0.14.54"
-    esbuild-linux-s390x "0.14.54"
-    esbuild-netbsd-64 "0.14.54"
-    esbuild-openbsd-64 "0.14.54"
-    esbuild-sunos-64 "0.14.54"
-    esbuild-windows-32 "0.14.54"
-    esbuild-windows-64 "0.14.54"
-    esbuild-windows-arm64 "0.14.54"
-
-esbuild@^0.18.10:
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
-  integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
-  optionalDependencies:
-    "@esbuild/android-arm" "0.18.20"
-    "@esbuild/android-arm64" "0.18.20"
-    "@esbuild/android-x64" "0.18.20"
-    "@esbuild/darwin-arm64" "0.18.20"
-    "@esbuild/darwin-x64" "0.18.20"
-    "@esbuild/freebsd-arm64" "0.18.20"
-    "@esbuild/freebsd-x64" "0.18.20"
-    "@esbuild/linux-arm" "0.18.20"
-    "@esbuild/linux-arm64" "0.18.20"
-    "@esbuild/linux-ia32" "0.18.20"
-    "@esbuild/linux-loong64" "0.18.20"
-    "@esbuild/linux-mips64el" "0.18.20"
-    "@esbuild/linux-ppc64" "0.18.20"
-    "@esbuild/linux-riscv64" "0.18.20"
-    "@esbuild/linux-s390x" "0.18.20"
-    "@esbuild/linux-x64" "0.18.20"
-    "@esbuild/netbsd-x64" "0.18.20"
-    "@esbuild/openbsd-x64" "0.18.20"
-    "@esbuild/sunos-x64" "0.18.20"
-    "@esbuild/win32-arm64" "0.18.20"
-    "@esbuild/win32-ia32" "0.18.20"
-    "@esbuild/win32-x64" "0.18.20"
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-google@^0.14.0:
   version "0.14.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.14.0.tgz#4f5f8759ba6e11b424294a219dbfa18c508bcc1a"
+  resolved "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz"
   integrity sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==
 
 eslint-plugin-vue@^9.8.0:
-  version "9.33.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-9.33.0.tgz#de33eba8f78e1d172c59c8ec7fbfd60c6ca35c39"
-  integrity sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==
+  version "9.19.2"
+  resolved "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.19.2.tgz"
+  integrity sha512-CPDqTOG2K4Ni2o4J5wixkLVNwgctKXFu6oBpVJlpNq7f38lh9I80pRTouZSJ2MAebPJlINU/KTFSXyQfBUlymA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
-    globals "^13.24.0"
     natural-compare "^1.4.0"
     nth-check "^2.1.1"
-    postcss-selector-parser "^6.0.15"
-    semver "^7.6.3"
-    vue-eslint-parser "^9.4.3"
+    postcss-selector-parser "^6.0.13"
+    semver "^7.5.4"
+    vue-eslint-parser "^9.3.1"
     xml-name-validator "^4.0.0"
 
 eslint-scope@^7.1.1, eslint-scope@^7.2.2:
   version "7.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz"
   integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
@@ -932,19 +774,19 @@ eslint-scope@^7.1.1, eslint-scope@^7.2.2:
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@^8.31.0:
-  version "8.57.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
-  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
+  version "8.56.0"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz"
+  integrity sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.6.1"
     "@eslint/eslintrc" "^2.1.4"
-    "@eslint/js" "8.57.1"
-    "@humanwhocodes/config-array" "^0.13.0"
+    "@eslint/js" "8.56.0"
+    "@humanwhocodes/config-array" "^0.11.13"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
     "@ungap/structured-clone" "^1.2.0"
@@ -981,7 +823,7 @@ eslint@^8.31.0:
 
 espree@^9.3.1, espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz"
   integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
     acorn "^8.9.0"
@@ -989,80 +831,62 @@ espree@^9.3.1, espree@^9.6.0, espree@^9.6.1:
     eslint-visitor-keys "^3.4.1"
 
 esquery@^1.4.0, esquery@^1.4.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
-  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
 
 estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-estree-walker@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-glob@^3.2.11:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
-  integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz"
+  integrity sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==
   dependencies:
     reusify "^1.0.4"
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-filelist@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
-  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
-  dependencies:
-    minimatch "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1073,7 +897,7 @@ fill-range@^7.1.1:
 
 find-up@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -1081,7 +905,7 @@ find-up@^5.0.0:
 
 flat-cache@^3.0.4:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz"
   integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
   dependencies:
     flatted "^3.2.9"
@@ -1089,19 +913,19 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+  version "3.4.2"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.15.6:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -1109,33 +933,24 @@ form-data@^4.0.4:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-fs-extra@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -1151,29 +966,22 @@ get-intrinsic@^1.2.6:
 
 get-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  resolved "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz"
   integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-glob-parent@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-parent@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
 
 glob@^7.1.3:
   version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
   dependencies:
     fs.realpath "^1.0.0"
@@ -1183,96 +991,81 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^13.19.0, globals@^13.24.0:
+globals@^13.19.0:
   version "13.24.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz"
   integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
   dependencies:
     type-fest "^0.20.2"
 
 gopd@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 has-tostringtag@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
   integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
   dependencies:
     has-symbols "^1.0.3"
 
 hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz"
+  integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
   dependencies:
     function-bind "^1.1.2"
 
-he@1.2.0, he@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-html-minifier-terser@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#bfc818934cc07918f6b3669f5774ecdfd48f32ab"
-  integrity sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
-    camel-case "^4.1.2"
-    clean-css "^5.2.2"
-    commander "^8.3.0"
-    he "^1.2.0"
-    param-case "^3.0.4"
-    relateurl "^0.2.7"
-    terser "^5.10.0"
+    agent-base "6"
+    debug "4"
 
 ignore@^5.2.0:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
-  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
-immutable@^5.0.2:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.3.tgz#e6486694c8b76c37c063cca92399fa64098634d4"
-  integrity sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==
+immutable@^5.1.5:
+  version "5.1.5"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz"
+  integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
 
 import-fresh@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
-  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
   integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
@@ -1280,17 +1073,17 @@ inflight@^1.0.4:
 
 inherits@2:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
@@ -1302,64 +1095,46 @@ is-number@^7.0.0:
 
 is-path-inside@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jake@^10.8.5:
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
-  integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==
-  dependencies:
-    async "^3.2.6"
-    filelist "^1.0.4"
-    picocolors "^1.1.1"
-
 js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 
 json-buffer@3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
-jsonfile@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.0.tgz#7c265bd1b65de6977478300087c99f1c84383f62"
-  integrity sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 keyv@^4.5.3:
   version "4.5.4"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
 
 levn@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
   integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
     prelude-ls "^1.2.1"
@@ -1367,390 +1142,347 @@ levn@^0.4.1:
 
 locate-path@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
 
 lodash.merge@^4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
-    tslib "^2.0.3"
+    yallist "^4.0.0"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-micromatch@^4.0.5, micromatch@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12:
   version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 moment@^2.29.4:
   version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
-ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.12:
+  version "3.3.12"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
 
 node-addon-api@^7.0.0:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-fetch@^2.6.7:
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
-node-html-parser@^5.3.3:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-5.4.2.tgz#93e004038c17af80226c942336990a0eaed8136a"
-  integrity sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==
-  dependencies:
-    css-select "^4.2.1"
-    he "1.2.0"
-
-nth-check@^2.0.1, nth-check@^2.1.1:
+nth-check@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
 optionator@^0.9.3:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
-  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  version "0.9.3"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz"
+  integrity sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==
   dependencies:
+    "@aashutoshrathi/word-wrap" "^1.2.3"
     deep-is "^0.1.3"
     fast-levenshtein "^2.0.6"
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
-    word-wrap "^1.2.5"
 
 p-limit@^3.0.2:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
 
-param-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
-  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
-
 parent-module@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
-pascal-case@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
 path-exists@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
-pathe@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.2.0.tgz#30fd7bbe0a0d91f0e60bae621f5d19e9e225c339"
-  integrity sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==
 
 picocolors@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.2.2, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 popper.js@^1.16.1:
   version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portal-vue@^2.1.7:
   version "2.1.7"
-  resolved "https://registry.yarnpkg.com/portal-vue/-/portal-vue-2.1.7.tgz#ea08069b25b640ca08a5b86f67c612f15f4e4ad4"
+  resolved "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz"
   integrity sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==
 
-postcss-selector-parser@^6.0.15:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+postcss-selector-parser@^6.0.13:
+  version "6.0.15"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz"
+  integrity sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@^8.4.14, postcss@^8.4.27, postcss@^8.4.31:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
-  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+postcss@^8.4.14, postcss@^8.4.31, postcss@^8.5.6:
+  version "8.5.15"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.12"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 "prettier@^1.18.2 || ^2.0.0":
   version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-readdirp@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
-  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
-
-relateurl@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
-  integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+readdirp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz"
+  integrity sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==
 
 resolve-from@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 reusify@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
-  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
-rollup@^3.27.1:
-  version "3.29.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.5.tgz#8a2e477a758b520fb78daf04bca4c522c1da8a54"
-  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
+rollup@^4.43.0:
+  version "4.60.4"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz"
+  integrity sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==
+  dependencies:
+    "@types/estree" "1.0.8"
   optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.60.4"
+    "@rollup/rollup-android-arm64" "4.60.4"
+    "@rollup/rollup-darwin-arm64" "4.60.4"
+    "@rollup/rollup-darwin-x64" "4.60.4"
+    "@rollup/rollup-freebsd-arm64" "4.60.4"
+    "@rollup/rollup-freebsd-x64" "4.60.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.60.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.60.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.60.4"
+    "@rollup/rollup-linux-arm64-musl" "4.60.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.60.4"
+    "@rollup/rollup-linux-loong64-musl" "4.60.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.60.4"
+    "@rollup/rollup-linux-ppc64-musl" "4.60.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.60.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.60.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.60.4"
+    "@rollup/rollup-linux-x64-gnu" "4.60.4"
+    "@rollup/rollup-linux-x64-musl" "4.60.4"
+    "@rollup/rollup-openbsd-x64" "4.60.4"
+    "@rollup/rollup-openharmony-arm64" "4.60.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.60.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.60.4"
+    "@rollup/rollup-win32-x64-gnu" "4.60.4"
+    "@rollup/rollup-win32-x64-msvc" "4.60.4"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
 
 sass@^1.57.0:
-  version "1.93.2"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.93.2.tgz#e97d225d60f59a3b3dbb6d2ae3c1b955fd1f2cd1"
-  integrity sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==
+  version "1.100.0"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz"
+  integrity sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==
   dependencies:
-    chokidar "^4.0.0"
-    immutable "^5.0.2"
+    chokidar "^5.0.0"
+    immutable "^5.1.5"
     source-map-js ">=0.6.2 <2.0.0"
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
 
-semver@^7.3.6, semver@^7.6.3:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
-  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+semver@^7.3.6, semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map-support@~0.5.20:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
+source-map@^0.6.1:
   version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 stisla-theme@^1.0.5:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/stisla-theme/-/stisla-theme-1.0.6.tgz#ce0803c5218619b8301da7e735f27d4a40d69b1e"
+  resolved "https://registry.npmjs.org/stisla-theme/-/stisla-theme-1.0.6.tgz"
   integrity sha512-ccMXkEJ/u98db5Kp5Ubb1IIM0AArZu2hTznOrau2WCdoqPjR5wBvZevCVosSffN2OajhwwN2GkQ5e1LkD9y50w==
 
 strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
-terser@^5.10.0:
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.44.0.tgz#ebefb8e5b8579d93111bfdfc39d2cf63879f4a82"
-  integrity sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.15.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
 text-table@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+tinyglobby@^0.2.15:
+  version "0.2.16"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz"
+  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1761,81 +1493,51 @@ to-regex-range@^5.0.1:
 
 tr46@~0.0.3:
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
-tslib@^2.0.3:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
 
 type-fest@^0.20.2:
   version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-universalify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
-  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 uri-js@^4.2.2:
   version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vite-plugin-env-compatible@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-env-compatible/-/vite-plugin-env-compatible-1.1.1.tgz#2e11b059a5f3e8fc609d6a4bba84ca497081ee20"
-  integrity sha512-4lqhBWhOzP+SaCPoCVdmpM5cXzjKQV5jgFauxea488oOeElXo/kw6bXkMIooZhrh9q7gclTl8en6N9NmnqUwRQ==
-
-vite-plugin-html@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/vite-plugin-html/-/vite-plugin-html-3.2.2.tgz#661834fa09015d3fda48ba694dbaa809396f5f7a"
-  integrity sha512-vb9C9kcdzcIo/Oc3CLZVS03dL5pDlOFuhGlZYDCJ840BhWl/0nGeZWf3Qy7NlOayscY4Cm/QRgULCQkEZige5Q==
+vite@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz"
+  integrity sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==
   dependencies:
-    "@rollup/pluginutils" "^4.2.0"
-    colorette "^2.0.16"
-    connect-history-api-fallback "^1.6.0"
-    consola "^2.15.3"
-    dotenv "^16.0.0"
-    dotenv-expand "^8.0.2"
-    ejs "^3.1.6"
-    fast-glob "^3.2.11"
-    fs-extra "^10.0.1"
-    html-minifier-terser "^6.1.0"
-    node-html-parser "^5.3.3"
-    pathe "^0.2.0"
-
-vite@^4.0.5:
-  version "4.5.14"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.14.tgz#2e652bc1d898265d987d6543ce866ecd65fa4086"
-  integrity sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==
-  dependencies:
-    esbuild "^0.18.10"
-    postcss "^8.4.27"
-    rollup "^3.27.1"
+    esbuild "^0.27.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
   optionalDependencies:
-    fsevents "~2.3.2"
+    fsevents "~2.3.3"
 
-vue-eslint-parser@^9.4.3:
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz#9b04b22c71401f1e8bca9be7c3e3416a4bde76a8"
-  integrity sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==
+vue-eslint-parser@^9.3.1:
+  version "9.3.2"
+  resolved "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz"
+  integrity sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==
   dependencies:
     debug "^4.3.4"
     eslint-scope "^7.1.1"
@@ -1847,27 +1549,27 @@ vue-eslint-parser@^9.4.3:
 
 vue-functional-data-merge@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz#08a7797583b7f35680587f8a1d51d729aa1dc657"
+  resolved "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz"
   integrity sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA==
 
 vue-json-pretty@1.9.5:
   version "1.9.5"
-  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-1.9.5.tgz#b59861710e352ee50dc8fafde1090382fa655111"
+  resolved "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.9.5.tgz"
   integrity sha512-fwbiH/ky/raX1D4MXRZZLFeKm157e9AkumMD7Y+djdLU1Sb0Tp5q2iOPvCnkWNzRpUfxx/zUjONUG+MIWsqx/w==
 
 vue-router@^3.0.3:
   version "3.6.5"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.6.5.tgz#95847d52b9a7e3f1361cb605c8e6441f202afad8"
+  resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz"
   integrity sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==
 
 vue-select@^3.20.0:
   version "3.20.4"
-  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.20.4.tgz#cf1fee2e0dfad3b692b23895acf959b9971770de"
+  resolved "https://registry.npmjs.org/vue-select/-/vue-select-3.20.4.tgz"
   integrity sha512-pXIsDUnBR1075qHNEM7mKgX7YnHI3MfCO+7VmXSA1Hywplpqi52jOa0j6EHWQU6MnaW/mBZPuaQtgp3yvks2Kw==
 
 vue@^2.7.0:
   version "2.7.16"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.16.tgz#98c60de9def99c0e3da8dae59b304ead43b967c9"
+  resolved "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz"
   integrity sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==
   dependencies:
     "@vue/compiler-sfc" "2.7.16"
@@ -1875,17 +1577,17 @@ vue@^2.7.0:
 
 vuex@^3.0.1:
   version "3.6.2"
-  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
+  resolved "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz"
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
   integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
@@ -1893,27 +1595,27 @@ whatwg-url@^5.0.0:
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
-  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
-
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yocto-queue@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
+
 "@babel/parser@^7.23.5":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz"
@@ -192,6 +197,30 @@
   version "2.0.1"
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz"
   integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
+
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/curves@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-2.2.0.tgz#981be3aadc3bbfbcdb245e78cc97aa6f759246c2"
+  integrity sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==
+  dependencies:
+    "@noble/hashes" "2.2.0"
+
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+
+"@noble/hashes@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.2.0.tgz#22da1d16a469954fce877055d559900a6c73b63b"
+  integrity sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -442,6 +471,13 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
+
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
@@ -472,6 +508,11 @@ acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
 agent-base@6:
   version "6.0.2"
@@ -514,7 +555,7 @@ asynckit@^0.4.0:
 
 axios@^1.12.0:
   version "1.16.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
   integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
   dependencies:
     follow-redirects "^1.16.0"
@@ -526,6 +567,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -562,6 +608,13 @@ braces@>=3.0.3:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -859,6 +912,19 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+ethers@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.16.0.tgz#fff9b4f05d7a359c774ad6e91085a800f7fccf65"
+  integrity sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -866,7 +932,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
@@ -955,7 +1021,7 @@ function-bind@^1.1.2:
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
-  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -1078,7 +1144,7 @@ inflight@^1.0.4:
 
 inherits@2:
   version "2.0.4"
-  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-extglob@^2.1.1:
@@ -1215,7 +1281,7 @@ node-addon-api@^7.0.0:
 
 node-fetch@^2.6.7:
   version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
@@ -1229,7 +1295,7 @@ nth-check@^2.1.1:
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
@@ -1289,7 +1355,7 @@ picocolors@^1.1.1:
 
 picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 popper.js@^1.16.1:
@@ -1496,6 +1562,11 @@ tr46@~0.0.3:
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+tslib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -1508,6 +1579,11 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
@@ -1517,7 +1593,7 @@ uri-js@^4.2.2:
 
 util-deprecate@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 vite@^7.3.3:
@@ -1604,6 +1680,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
 Rebuild of the explorer on top of the existing Vue 2 / bootstrap-vue stack: 
 
 mobile-friendly, etherscan-style dashboard, new Verifier and Ecosystem pages,
 fixed sidebar with brand links, and ~17 bug fixes against the existing API endpoints